### PR TITLE
YONK-377: adds ability to exclude users with certain roles

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='1.0.4',
+    version='1.0.5',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
This PR updates CoursesMetricsGradesLeadersList api to support filtering of users with certain roles. Roles can be filtered via exclude_roles query string. For example to exclude observer role we can pass values like exclude_roles=observer and if we don't want to apply any role filtering we can pass exclude_roles=none query string.

@ziafazal would you please review?

