### PR TITLE
added commit_on_success to context context manager

### DIFF
--- a/edx_solutions_api_integration/management/commands/rename_api_manager_app.py
+++ b/edx_solutions_api_integration/management/commands/rename_api_manager_app.py
@@ -4,6 +4,7 @@ Management command to rename api_manager app to edx_solutions_api_integration
 import logging
 from south.db import db
 from django.core.management.base import BaseCommand
+from django.db import transaction
 
 log = logging.getLogger(__name__)
 
@@ -43,10 +44,11 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         log.info('renaming api_manager app and related tables')
 
-        db.execute("UPDATE south_migrationhistory SET app_name = %s WHERE app_name = %s", [get_new_appname(), get_old_appname()])  # pylint: disable=line-too-long
-        db.execute("UPDATE django_content_type SET app_label = %s WHERE app_label = %s", [get_new_appname(), get_old_appname()])  # pylint: disable=line-too-long
+        with transaction.commit_on_success():
+            db.execute("UPDATE south_migrationhistory SET app_name = %s WHERE app_name = %s", [get_new_appname(), get_old_appname()])  # pylint: disable=line-too-long
+            db.execute("UPDATE django_content_type SET app_label = %s WHERE app_label = %s", [get_new_appname(), get_old_appname()])  # pylint: disable=line-too-long
 
-        for old_table_name, new_table_name in get_table_name_mappings().items():
-            db.rename_table(old_table_name, new_table_name)
+            for old_table_name, new_table_name in get_table_name_mappings().items():
+                db.rename_table(old_table_name, new_table_name)
 
-        log.info('api_manager app and related tables successfully renamed')
+            log.info('api_manager app and related tables successfully renamed')

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='1.0.5',
+    version='1.0.6',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
This PR wraps database operations around `transaction.commit_on_success` context manager to make sure changes are only committed when all statements are executed successfully.

@saleem-latif would you please review?