### PR TITLE
Fix for story [YONK-421]: Error in SessionsList api.

### DIFF
--- a/edx_solutions_api_integration/sessions/tests.py
+++ b/edx_solutions_api_integration/sessions/tests.py
@@ -180,3 +180,14 @@ class SessionsApiTests(TestCase, APIClientMixin):
         test_uri = self.base_sessions_uri + "214viouadblah124324blahblah"
         response = self.do_delete(test_uri)
         self.assertEqual(response.status_code, 204)
+
+    def test_sessions_list_missing_username(self):
+        # Test with missing username in request data
+        response = self.do_post(self.base_sessions_uri, {})
+        self.assertEqual(response.status_code, 400)
+
+    def test_sessions_list_missing_password(self):
+        # Test with missing password in request data
+        response = self.do_post(self.base_sessions_uri, {'username': self.test_username})
+        self.assertEqual(response.status_code, 400)
+

--- a/edx_solutions_api_integration/sessions/views.py
+++ b/edx_solutions_api_integration/sessions/views.py
@@ -73,8 +73,17 @@ class SessionsList(SecureAPIView):
             return Response(response_data, status=status.HTTP_403_FORBIDDEN)
 
         base_uri = generate_base_uri(request)
+
+        username = request.data.get('username', None)
+        if username is None:
+            return Response({'message': _('username is missing')}, status=status.HTTP_400_BAD_REQUEST)
+
+        password = request.data.get('password', None)
+        if password is None:
+            return Response({'message': _('password is missing')}, status=status.HTTP_400_BAD_REQUEST)
+
         try:
-            existing_user = User.objects.get(username=request.data['username'])
+            existing_user = User.objects.get(username=username)
         except ObjectDoesNotExist:
             existing_user = None
 
@@ -96,7 +105,7 @@ class SessionsList(SecureAPIView):
             return Response(response_data, status=response_status)
 
         if existing_user:
-            user = authenticate(username=existing_user.username, password=request.data['password'])
+            user = authenticate(username=existing_user.username, password=password)
             if user is not None:
 
                 # successful login, clear failed login attempts counters, if applicable


### PR DESCRIPTION
@ziafazal 

The checks have been added for both username and password and if any of these two is missing, HTTP_400_BAD_REQUEST response is sent. 
Also two unit tests are added for this change, one with the missing username and the other with missing password.

Here is the link of JIRA story;
https://openedx.atlassian.net/browse/YONK-421