### PR TITLE
Fix for story [YONK-422]: Error in CoursesUsersList api.

### DIFF
--- a/edx_solutions_api_integration/courses/tests.py
+++ b/edx_solutions_api_integration/courses/tests.py
@@ -2525,11 +2525,11 @@ class CoursesApiTests(
             response.data
         )
 
-    def test_courses_users_list_valid_email_no_content_response(self):
-        # Test with valid email in request data, it should return response status HTTP_204_NO_CONTENT
+    def test_courses_users_list_valid_email_enroll_user(self):
+        # Test with valid email in request data, it should return response status HTTP_201_CREATED
         test_uri = '{}/{}/users'.format(self.base_courses_uri, self.course.id)
         response = self.do_post(test_uri, {'email': self.users[0].email})
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 201)
 
 
 @override_settings(MODULESTORE=MODULESTORE_CONFIG)

--- a/edx_solutions_api_integration/courses/tests.py
+++ b/edx_solutions_api_integration/courses/tests.py
@@ -2525,6 +2525,12 @@ class CoursesApiTests(
             response.data
         )
 
+    def test_courses_users_list_valid_email_no_content_response(self):
+        # Test with valid email in request data, it should return response status HTTP_204_NO_CONTENT
+        test_uri = '{}/{}/users'.format(self.base_courses_uri, self.course.id)
+        response = self.do_post(test_uri, {'email': self.users[0].email})
+        self.assertEqual(response.status_code, 204)
+
 
 @override_settings(MODULESTORE=MODULESTORE_CONFIG)
 @mock.patch.dict("django.conf.settings.FEATURES", {'ENFORCE_PASSWORD_POLICY': False,

--- a/edx_solutions_api_integration/courses/views.py
+++ b/edx_solutions_api_integration/courses/views.py
@@ -1093,6 +1093,8 @@ class CoursesUsersList(SecureListAPIView):
         else:
             return Response({}, status=status.HTTP_400_BAD_REQUEST)
 
+        return Response({}, status=status.HTTP_204_NO_CONTENT)
+
     def get(self, request, course_id):  # pylint: disable=W0221
         """
         GET /api/courses/{course_id}/users

--- a/edx_solutions_api_integration/courses/views.py
+++ b/edx_solutions_api_integration/courses/views.py
@@ -1066,14 +1066,13 @@ class CoursesUsersList(SecureListAPIView):
         if not course_exists(request, request.user, course_id):
             return Response({}, status=status.HTTP_404_NOT_FOUND)
         course_key = get_course_key(course_id)
+        existing_user = None
         if 'user_id' in request.data:
             user_id = request.data['user_id']
             try:
                 existing_user = User.objects.get(id=user_id)
             except ObjectDoesNotExist:
                 return Response({}, status=status.HTTP_404_NOT_FOUND)
-            CourseEnrollment.enroll(existing_user, course_key)
-            return Response({}, status=status.HTTP_201_CREATED)
         elif 'email' in request.data:
             try:
                 email = request.data['email']
@@ -1093,7 +1092,8 @@ class CoursesUsersList(SecureListAPIView):
         else:
             return Response({}, status=status.HTTP_400_BAD_REQUEST)
 
-        return Response({}, status=status.HTTP_204_NO_CONTENT)
+        CourseEnrollment.enroll(existing_user, course_key)
+        return Response({}, status=status.HTTP_201_CREATED)
 
     def get(self, request, course_id):  # pylint: disable=W0221
         """


### PR DESCRIPTION
@ziafazal 

A fix has been added that in case of valid email provided in the request data, HTTP_204_NO_CONTENT should be sent. A unit test is also added to verify this change.

Here is the link to the JIRA story;
https://openedx.atlassian.net/browse/YONK-422