### PR TITLE
Fix for story [YONK-420]: Error in GroupsCoursesList api.

### DIFF
--- a/edx_solutions_api_integration/groups/tests.py
+++ b/edx_solutions_api_integration/groups/tests.py
@@ -1043,5 +1043,6 @@ class GroupsApiTests(ModuleStoreTestCase, APIClientMixin):
 
         # Test with missing course_id in the request data
         test_uri = '{}/{}/courses/'.format(self.base_groups_uri, test_group.id)
-        response = self.do_post(test_uri, {})
+        data = {"course_id": ""}
+        response = self.do_post(test_uri, data)
         self.assertEqual(response.status_code, 400)

--- a/edx_solutions_api_integration/groups/tests.py
+++ b/edx_solutions_api_integration/groups/tests.py
@@ -1036,3 +1036,12 @@ class GroupsApiTests(ModuleStoreTestCase, APIClientMixin):
         response = self.do_get(test_uri)
         self.assertEqual(response.status_code, 404)
 
+    def test_groups_courses_list_missing_course_id(self):
+
+        # Create test group
+        test_group = GroupFactory.create()
+
+        # Test with missing course_id in the request data
+        test_uri = '{}/{}/courses/'.format(self.base_groups_uri, test_group.id)
+        response = self.do_post(test_uri, {})
+        self.assertEqual(response.status_code, 400)

--- a/edx_solutions_api_integration/groups/views.py
+++ b/edx_solutions_api_integration/groups/views.py
@@ -554,7 +554,10 @@ class GroupsCoursesList(SecureAPIView):
             existing_group = Group.objects.get(id=group_id)
         except ObjectDoesNotExist:
             return Response({}, status.HTTP_404_NOT_FOUND)
-        course_id = request.data['course_id']
+
+        course_id = request.data.get('course_id', None)
+        if course_id is None:
+            return Response({'message': _('course_id is missing')}, status=status.HTTP_400_BAD_REQUEST)
 
         base_uri = generate_base_uri(request)
         response_data['uri'] = '{}/{}'.format(base_uri, course_id)

--- a/edx_solutions_api_integration/groups/views.py
+++ b/edx_solutions_api_integration/groups/views.py
@@ -556,7 +556,7 @@ class GroupsCoursesList(SecureAPIView):
             return Response({}, status.HTTP_404_NOT_FOUND)
 
         course_id = request.data.get('course_id', None)
-        if course_id is None:
+        if not course_id:
             return Response({'message': _('course_id is missing')}, status=status.HTTP_400_BAD_REQUEST)
 
         base_uri = generate_base_uri(request)


### PR DESCRIPTION
@ziafazal 

A check is added that if course_id is missing in the request data, HTTP_400_BAD_REQUEST is sent back. Also a unit test is added to verify this change.

Here is the link to the JIRA story;
https://openedx.atlassian.net/browse/YONK-420