### PR TITLE
Fix for story [YONK-425]: Error in CoursesGroupsList api

### DIFF
--- a/edx_solutions_api_integration/courses/tests.py
+++ b/edx_solutions_api_integration/courses/tests.py
@@ -2525,6 +2525,12 @@ class CoursesApiTests(
             response.data
         )
 
+    def test_courses_groups_list_missing_group_id(self):
+        # Test with missing group_id in request data
+        test_uri = '{}/{}/groups'.format(self.base_courses_uri, self.test_course_id)
+        response = self.do_post(test_uri, {})
+        self.assertEqual(response.status_code, 400)
+
 
 @override_settings(MODULESTORE=MODULESTORE_CONFIG)
 @mock.patch.dict("django.conf.settings.FEATURES", {'ENFORCE_PASSWORD_POLICY': False,

--- a/edx_solutions_api_integration/courses/views.py
+++ b/edx_solutions_api_integration/courses/views.py
@@ -729,7 +729,10 @@ class CoursesGroupsList(SecureAPIView):
         POST /api/courses/{course_id}/groups
         """
         response_data = {}
-        group_id = request.data['group_id']
+        group_id = request.data.get('group_id', None)
+        if not group_id:
+            return Response({'message': _('group_id is missing')}, status.HTTP_400_BAD_REQUEST)
+
         base_uri = generate_base_uri(request)
         if not course_exists(request, request.user, course_id):
             return Response({}, status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
@ziafazal 

A fix is added to send HTTP_400_BAD_REQUEST back in case 'group_id' is missing is request data. A unit test is also added for this fix.

Here is the link to the JIRA story;
https://openedx.atlassian.net/browse/YONK-425