### PR TITLE
Fix for story [YONK-424]: Error in CoursesTimeSeriesMetrics api.

### DIFF
--- a/edx_solutions_api_integration/courses/tests.py
+++ b/edx_solutions_api_integration/courses/tests.py
@@ -3003,6 +3003,29 @@ class CoursesTimeSeriesMetricsApiTests(SignalDisconnectTestMixin, SharedModuleSt
         response = self.do_get(course_metrics_uri)
         self.assertEqual(response.status_code, 400)
 
+    def test_courses_time_series_invalid_start_date(self):
+         # Test with an invalid format of start_date
+         test_uri = '{}/{}/time-series-metrics/?start_date={}&end_date={}'.format(
+             self.base_courses_uri,
+             self.course.id,
+             '21102016',
+             self.reference_date
+         )
+         response = self.do_get(test_uri)
+         self.assertEqual(response.status_code, 400)
+
+    def test_courses_time_series_invalid_end_date(self):
+        # Test with an invalid format of end_date
+        start_date = self.reference_date - relativedelta(days=10)
+        test_uri = '{}/{}/time-series-metrics/?start_date={}&end_date={}'.format(
+         self.base_courses_uri,
+         self.course.id,
+         start_date,
+         '21102016'
+        )
+        response = self.do_get(test_uri)
+        self.assertEqual(response.status_code, 400)
+
 
 @override_settings(MODULESTORE=MODULESTORE_CONFIG)
 class CoursesGradingMetricsTests(

--- a/edx_solutions_api_integration/courses/views.py
+++ b/edx_solutions_api_integration/courses/views.py
@@ -1661,8 +1661,12 @@ class CoursesTimeSeriesMetrics(SecureAPIView):
         if interval not in ['days', 'weeks', 'months']:
             return Response({"message": _("Interval parameter is not valid. It should be one of these "
                                           "'days', 'weeks', 'months'")}, status=status.HTTP_400_BAD_REQUEST)
-        start_dt = parse_datetime(start)
-        end_dt = parse_datetime(end)
+        try:
+            start_dt = parse_datetime(start)
+            end_dt = parse_datetime(end)
+        except ValueError:
+            return Response({'message': _('date format is invalid')}, status=status.HTTP_400_BAD_REQUEST)
+
         course_key = get_course_key(course_id)
         exclude_users = get_aggregate_exclusion_user_ids(course_key)
         grade_complete_match_range = getattr(settings, 'GRADEBOOK_GRADE_COMPLETE_PROFORMA_MATCH_RANGE', 0.01)


### PR DESCRIPTION
@ziafazal 
A check is added to validate the format of start and end dates and HTTP_400_BAD_REQUEST should be sent back in case of invalid format. Also the unit tests are added to verify this fix.

Here is the link to the JIRA story;
https://openedx.atlassian.net/projects/YONK/issues/YONK-424