### PR TITLE
Fix for story [YONK-454]: Error in UsersList api.

### DIFF
--- a/edx_solutions_api_integration/users/tests.py
+++ b/edx_solutions_api_integration/users/tests.py
@@ -2204,19 +2204,19 @@ class UsersApiTests(SignalDisconnectTestMixin, ModuleStoreTestCase, CacheIsolati
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['position'], None)
 
-    def test_users_list_missing_email(self):
+    def test_users_list_post_missing_email(self):
         # Test with missing email in the request data
         data = {'username': self.test_username, 'password': self.test_password}
         response = self.do_post(self.users_base_uri, data)
         self.assertEqual(response.status_code, 400)
 
-    def test_users_list_missing_username(self):
+    def test_users_list_post_missing_username(self):
         # Test with missing username in the request data
         data = {'email': self.test_email, 'password': self.test_password}
         response = self.do_post(self.users_base_uri, data)
         self.assertEqual(response.status_code, 400)
 
-    def test_users_list_missing_password(self):
+    def test_users_list_post_missing_password(self):
         # Test with missing password in the request data
         data = {'email': self.test_email, 'username': self.test_username}
         response = self.do_post(self.users_base_uri, data)

--- a/edx_solutions_api_integration/users/tests.py
+++ b/edx_solutions_api_integration/users/tests.py
@@ -2204,4 +2204,24 @@ class UsersApiTests(SignalDisconnectTestMixin, ModuleStoreTestCase, CacheIsolati
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['position'], None)
 
+    def test_users_list_missing_email(self):
+        # Test with missing email in the request data
+        data = {'username': self.test_username, 'password': self.test_password}
+        response = self.do_post(self.users_base_uri, data)
+        self.assertEqual(response.status_code, 400)
+
+    def test_users_list_missing_username(self):
+        # Test with missing username in the request data
+        data = {'email': self.test_email, 'password': self.test_password}
+        response = self.do_post(self.users_base_uri, data)
+        self.assertEqual(response.status_code, 400)
+
+    def test_users_list_missing_password(self):
+        # Test with missing password in the request data
+        data = {'email': self.test_email, 'username': self.test_username}
+        response = self.do_post(self.users_base_uri, data)
+        self.assertEqual(response.status_code, 400)
+
+
+
 

--- a/edx_solutions_api_integration/users/views.py
+++ b/edx_solutions_api_integration/users/views.py
@@ -327,9 +327,19 @@ class UsersList(SecureListAPIView):
         """
         response_data = {}
         base_uri = generate_base_uri(request)
-        email = request.data['email']
-        username = request.data['username']
-        password = request.data['password']
+
+        email = request.data.get('email')
+        if email is None:
+            return Response({'message': _('email is missing')}, status.HTTP_400_BAD_REQUEST)
+
+        username = request.data.get('username')
+        if username is None:
+            return Response({'message': _('username is missing')}, status.HTTP_400_BAD_REQUEST)
+
+        password = request.data.get('password')
+        if password is None:
+            return Response({'message': _('password is missing')}, status.HTTP_400_BAD_REQUEST)
+
         first_name = request.data.get('first_name', '')
         last_name = request.data.get('last_name', '')
         is_active = request.data.get('is_active', None)

--- a/edx_solutions_api_integration/users/views.py
+++ b/edx_solutions_api_integration/users/views.py
@@ -329,15 +329,12 @@ class UsersList(SecureListAPIView):
         base_uri = generate_base_uri(request)
 
         email = request.data.get('email')
-        if email is None:
-            return Response({'message': _('email is missing')}, status.HTTP_400_BAD_REQUEST)
-
         username = request.data.get('username')
         if username is None:
             return Response({'message': _('username is missing')}, status.HTTP_400_BAD_REQUEST)
 
         password = request.data.get('password')
-        if password is None:
+        if settings.FEATURES.get('ENFORCE_PASSWORD_POLICY', True) and password is None:
             return Response({'message': _('password is missing')}, status.HTTP_400_BAD_REQUEST)
 
         first_name = request.data.get('first_name', '')


### PR DESCRIPTION
@ziafazal 
A change has been made so that if email, username or password are not provided in the request data, HTTP_400_BAD_REQUEST is sent back. The corresponding unit tests for these fields are also added.

Here is the link to the JIRA story;
https://openedx.atlassian.net/projects/YONK/issues/YONK-454
