### PR TITLE
Fix for story [YONK-456]: Error in UsersGroupsDetail api.

### DIFF
--- a/edx_solutions_api_integration/users/tests.py
+++ b/edx_solutions_api_integration/users/tests.py
@@ -36,7 +36,7 @@ from edx_solutions_api_integration.test_utils import (
     APIClientMixin,
     SignalDisconnectTestMixin,
 )
-from student.tests.factories import UserFactory, CourseEnrollmentFactory
+from student.tests.factories import UserFactory, CourseEnrollmentFactory, GroupFactory
 from student.models import anonymous_id_for_user
 
 from openedx.core.djangoapps.user_api.models import UserPreference
@@ -2204,4 +2204,10 @@ class UsersApiTests(SignalDisconnectTestMixin, ModuleStoreTestCase, CacheIsolati
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['position'], None)
 
+    def test_users_groups_detail_delete_invalid_user_id(self):
+        # Test with invalid user_id
+        test_group = GroupFactory.create()
+        test_uri = '{}/{}/groups/{}'.format(self.users_base_uri, '1234567', test_group.id)
+        response = self.do_delete(test_uri)
+        self.assertEqual(response.status_code, 404)
 

--- a/edx_solutions_api_integration/users/views.py
+++ b/edx_solutions_api_integration/users/views.py
@@ -766,7 +766,11 @@ class UsersGroupsDetail(SecureAPIView):
         """
         DELETE /api/users/{user_id}/groups/{group_id}
         """
-        existing_user = User.objects.get(id=user_id)
+        try:
+            existing_user = User.objects.get(id=user_id)
+        except ObjectDoesNotExist:
+            return Response({}, status.HTTP_404_NOT_FOUND)
+
         existing_user.groups.remove(group_id)
         existing_user.save()
         return Response({}, status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
@ziafazal 

A check is added that if given user_id does not exist, it should send HTTP_404_NOT_FOUND status code. Also a unit test is added for this change.

Here is the link to the JIRA story;
https://openedx.atlassian.net/projects/YONK/issues/YONK-456