### PR TITLE
Fix for story [YONK-457]: Error in UsersCoursesList api.

### DIFF
--- a/edx_solutions_api_integration/users/tests.py
+++ b/edx_solutions_api_integration/users/tests.py
@@ -2204,4 +2204,11 @@ class UsersApiTests(SignalDisconnectTestMixin, ModuleStoreTestCase, CacheIsolati
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['position'], None)
 
+    def test_users_courses_list_post_missing_course_id(self):
+        # Test with missing course_id in request data
+        test_uri = '{}/{}/courses/'.format(self.users_base_uri, self.user.id)
+        data = {'course_id': ''}
+        response = self.do_post(test_uri, data)
+        self.assertEqual(response.status_code, 400)
+
 

--- a/edx_solutions_api_integration/users/views.py
+++ b/edx_solutions_api_integration/users/views.py
@@ -795,7 +795,10 @@ class UsersCoursesList(SecureAPIView):
         """
         response_data = {}
         user_id = user_id
-        course_id = request.data['course_id']
+        course_id = request.data.get('course_id')
+        if not course_id:
+            return Response({'message': _('course_id is missing')}, status.HTTP_400_BAD_REQUEST)
+
         try:
             user = User.objects.get(id=user_id)
             course_descriptor, course_key, course_content = get_course(request, user, course_id)  # pylint: disable=W0612,C0301


### PR DESCRIPTION
@ziafazal 
A check is added that if course_id is missing in request data or is empty HTTP_400_BAD_REQUEST is sent back. Also a unit test is added to verify the fix.

Here is the link to JIRA story;
https://openedx.atlassian.net/projects/YONK/issues/YONK-457