### PR TITLE
Fix for story [YONK-423]: Error in CoursesUsersDetail api.

### DIFF
--- a/edx_solutions_api_integration/courses/views.py
+++ b/edx_solutions_api_integration/courses/views.py
@@ -1200,7 +1200,7 @@ class CoursesUsersDetail(SecureAPIView):
         if not course_descriptor:
             return Response(response_data, status=status.HTTP_404_NOT_FOUND)
         if CourseEnrollment.is_enrolled(user, course_key):
-            response_data['position'] = course_content.position
+            response_data['position'] = getattr(course_content, 'position', None)
             response_status = status.HTTP_200_OK
         else:
             response_status = status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
@ziafazal 

A code change is made so that it checks if course_content is None before accessing that field. Also the corresponding unit test is added to verify this change.

Here is the link to the JIRA story;
https://openedx.atlassian.net/projects/YONK/issues/YONK-423
