### PR TITLE
Fix for story [YONK-458]: Error in post method of UsersCoursesDetail …

### DIFF
--- a/edx_solutions_api_integration/users/tests.py
+++ b/edx_solutions_api_integration/users/tests.py
@@ -2225,3 +2225,21 @@ class UsersApiTests(SignalDisconnectTestMixin, ModuleStoreTestCase, CacheIsolati
         response = self.do_post(test_uri, data)
         self.assertEqual(response.status_code, 400)
 
+    def test_users_courses_detail_post_missing_positions(self):
+        test_uri = '{}/{}/courses/{}'.format(self.users_base_uri, self.user.id, self.course.id)
+        response = self.do_post(test_uri, data={})
+        self.assertEqual(response.status_code, 200)
+
+    def test_users_courses_detail_post_missing_parent_content_id(self):
+        position_data = {'positions': [{'child_content_id': str(self.course.location)}]}
+        test_uri = '{}/{}/courses/{}'.format(self.users_base_uri, self.user.id, self.course.id)
+
+        response = self.do_post(test_uri, data=position_data)
+        self.assertEqual(response.status_code, 400)
+
+    def test_users_courses_detail_post_missing_child_content_id(self):
+        position_data = {'positions': [{'parent_content_id': str(self.course.id)}]}
+        test_uri = '{}/{}/courses/{}'.format(self.users_base_uri, self.user.id, self.course.id)
+
+        response = self.do_post(test_uri, data=position_data)
+        self.assertEqual(response.status_code, 400)

--- a/edx_solutions_api_integration/users/tests.py
+++ b/edx_solutions_api_integration/users/tests.py
@@ -2228,7 +2228,7 @@ class UsersApiTests(SignalDisconnectTestMixin, ModuleStoreTestCase, CacheIsolati
     def test_users_courses_detail_post_missing_positions(self):
         test_uri = '{}/{}/courses/{}'.format(self.users_base_uri, self.user.id, self.course.id)
         response = self.do_post(test_uri, data={})
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 400)
 
     def test_users_courses_detail_post_missing_parent_content_id(self):
         position_data = {'positions': [{'child_content_id': str(self.course.location)}]}

--- a/edx_solutions_api_integration/users/views.py
+++ b/edx_solutions_api_integration/users/views.py
@@ -101,8 +101,8 @@ def _save_content_position(request, user, course_key, position):
     Records the indicated position for the specified course
     Really no reason to generalize this out of user_courses_detail aside from pylint complaining
     """
-    parent_content_id = position['parent_content_id']
-    child_content_id = position['child_content_id']
+    parent_content_id = position.get('parent_content_id')
+    child_content_id = position.get('child_content_id')
     if unicode(course_key) == parent_content_id:
         parent_descriptor, parent_key, parent_content = get_course(request, user, parent_content_id, load_content=True)  # pylint: disable=W0612,C0301
     else:
@@ -938,10 +938,11 @@ class UsersCoursesDetail(SecureAPIView):
         response_data['user_id'] = user.id
         response_data['course_id'] = course_id
 
-        if request.data['positions']:
+        positions = request.data.get('positions')
+        if positions:
             course_key = get_course_key(course_id)
             response_data['positions'] = []
-            for position in request.data['positions']:
+            for position in positions:
                 content_position = _save_content_position(
                     request,
                     user,

--- a/edx_solutions_api_integration/users/views.py
+++ b/edx_solutions_api_integration/users/views.py
@@ -939,19 +939,21 @@ class UsersCoursesDetail(SecureAPIView):
         response_data['course_id'] = course_id
 
         positions = request.data.get('positions')
-        if positions:
-            course_key = get_course_key(course_id)
-            response_data['positions'] = []
-            for position in positions:
-                content_position = _save_content_position(
-                    request,
-                    user,
-                    course_key,
-                    position
-                )
-                if not content_position:
-                    return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
-                response_data['positions'].append(content_position)
+        if not positions:
+            return Response({}, status=status.HTTP_400_BAD_REQUEST)
+
+        course_key = get_course_key(course_id)
+        response_data['positions'] = []
+        for position in positions:
+            content_position = _save_content_position(
+                request,
+                user,
+                course_key,
+                position
+            )
+            if not content_position:
+                return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
+            response_data['positions'].append(content_position)
         return Response(response_data, status=status.HTTP_200_OK)
 
     def get(self, request, user_id, course_id):


### PR DESCRIPTION
@ziafazal 
The code has been changed to handle if "positions", "parent_content_id" or "child_content_id" is missing in the request data then 400_BAD_REQUEST is sent back. The corresponding unit tests are also added to verify the fix.

Here is the link of the JIRA story;
https://openedx.atlassian.net/projects/YONK/issues/YONK-458