### PR TITLE
Fix for story [YONK-460]: Error in UsersNotificationsDetail api.

### DIFF
--- a/edx_solutions_api_integration/users/tests.py
+++ b/edx_solutions_api_integration/users/tests.py
@@ -2225,3 +2225,8 @@ class UsersApiTests(SignalDisconnectTestMixin, ModuleStoreTestCase, CacheIsolati
         response = self.do_post(test_uri, data)
         self.assertEqual(response.status_code, 400)
 
+    def test_users_notifications_detail_missing_read_value(self):
+        test_uri = '{}/{}/notifications/{}/'.format(self.users_base_uri, self.user.id, '1')
+        response = self.do_post(test_uri, {})
+        self.assertEqual(response.status_code, 400)
+

--- a/edx_solutions_api_integration/users/views.py
+++ b/edx_solutions_api_integration/users/views.py
@@ -1521,8 +1521,10 @@ class UsersNotificationsDetail(SecureAPIView):
             }
         """
 
-        read = bool(request.data['read'])
+        read = request.data.get('read')
+        if not read:
+            return Response({'message': _('read field is missing')}, status.HTTP_400_BAD_REQUEST)
 
-        mark_notification_read(int(user_id), int(msg_id), read=read)
+        mark_notification_read(int(user_id), int(msg_id), read=bool(read))
 
         return Response({}, status=status.HTTP_201_CREATED)


### PR DESCRIPTION
@ziafazal 

A check is added so that if "read" is missing in the request data, HTTP_400_BAD_REQUEST should be sent back. Also the unit test is added to verify the change.

Here is the link to the JIRA story;
https://openedx.atlassian.net/projects/YONK/issues/YONK-460