### PR TITLE
Story [YONK-388]: Integrity Error in New Relic.

### DIFF
--- a/edx_solutions_api_integration/users/tests.py
+++ b/edx_solutions_api_integration/users/tests.py
@@ -2301,7 +2301,7 @@ class UsersApiTests(SignalDisconnectTestMixin, ModuleStoreTestCase, CacheIsolati
         """
         CourseEnrollmentFactory.create(user=self.user, course_id=self.course.id)
 
-        def get_users_courses_grades_detail(*a, **k):
+        def get_users_courses_grades_detail(*args):
             test_uri = '{}/{}/courses/{}/grades'.format(self.users_base_uri, self.user.id, unicode(self.course.id))
             response = self.do_get(test_uri)
             self.assertEqual(response.status_code, 200)

--- a/edx_solutions_api_integration/users/tests.py
+++ b/edx_solutions_api_integration/users/tests.py
@@ -2290,6 +2290,15 @@ class UsersApiTests(SignalDisconnectTestMixin, ModuleStoreTestCase, CacheIsolati
         self.assertEqual(response.status_code, 400)
 
     def test_users_courses_grades_detail_race_condition(self):
+        """
+        This unit test is written to create the race condition which caused IntegrityError in UsersCoursesGradesDetail
+        api when two threads try ko execute the generate_user_gradebook function at the same time. One thread
+        creates a new record in database and when other tries to create the record, error occurs.
+
+        Here we halt thread 1 execution at the point before it calls generate_user_gradebook method, the
+        thread 2 executes. Thread 2 will create new record and when thread 1 resume, it will find the new
+        record in the database which is handled with the get_or_create method in the api.
+        """
         CourseEnrollmentFactory.create(user=self.user, course_id=self.course.id)
 
         def get_users_courses_grades_detail(*a, **k):

--- a/edx_solutions_api_integration/users/tests.py
+++ b/edx_solutions_api_integration/users/tests.py
@@ -15,6 +15,7 @@ from edx_notifications.data import NotificationType, NotificationMessage
 from edx_notifications.lib.consumer import get_notifications_count_for_user
 from edx_notifications.lib.publisher import register_notification_type, publish_notification_to_user
 import mock
+import before_after
 
 from django.conf import settings
 from django.core.cache import cache
@@ -47,7 +48,6 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, mixed_st
 from django.contrib.auth.models import User
 from notification_prefs import NOTIFICATION_PREF_KEY
 
-import before_after
 
 MODULESTORE_CONFIG = mixed_store_config(settings.COMMON_TEST_DATA_ROOT, {})
 


### PR DESCRIPTION
@ziafazal:

A unit test has been added to verify the fix which is made in the gradebook app. (In gradebook app, changes are made to handle the integrity error with the get_or_create method which occurred at the create function if the object existed already in the database)

Here is the link to the JIRA story;
https://openedx.atlassian.net/projects/YONK/issues/YONK-388