### PR TITLE
YONK-399: UsersDetail.post API should support unicode data in user name

### DIFF
--- a/edx_solutions_api_integration/users/tests.py
+++ b/edx_solutions_api_integration/users/tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # pylint: disable=E1101
 # pylint: disable=E1103
 
@@ -2308,3 +2309,21 @@ class UsersApiTests(SignalDisconnectTestMixin, ModuleStoreTestCase, CacheIsolati
 
         with before_after.before('gradebook.utils.generate_user_gradebook', get_users_courses_grades_detail):
             get_users_courses_grades_detail()
+
+    def test_user_detail_post_unicode_data(self):
+        test_first_name = u'Miké'
+        test_last_name = u'Meÿers'
+
+        test_uri = '{}/{}'.format(self.users_base_uri, self.user.id)
+        data = {
+            'first_name': test_first_name,
+            'last_name': test_last_name
+        }
+        response = self.do_post(test_uri, data)
+        self.assertEqual(response.status_code, 200)
+
+        response = self.do_get(test_uri)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['first_name'], test_first_name)
+        self.assertEqual(response.data['last_name'], test_last_name)
+        self.assertEqual(response.data['full_name'], u'{} {}'.format(test_first_name, test_last_name))

--- a/edx_solutions_api_integration/users/views.py
+++ b/edx_solutions_api_integration/users/views.py
@@ -630,7 +630,7 @@ class UsersDetail(SecureAPIView):
         existing_user_profile = UserProfile.objects.get(user_id=user_id)
         if existing_user_profile:
             if first_name and last_name:
-                existing_user_profile.name = '{} {}'.format(first_name, last_name)
+                existing_user_profile.name = u'{} {}'.format(first_name, last_name)
             city = request.data.get('city')
             if city:
                 existing_user_profile.city = city


### PR DESCRIPTION
@ziafazal 
The code has been changed to properly handle unicode data in first and last names. Also the unit test is added to test the change.

Here is the link of the JIRA story;
https://openedx.atlassian.net/projects/YONK/issues/YONK-399