### PR TITLE
document APIs required for building certificates at Apros

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3067,6 +3067,20 @@ Returns navigation information
         }
 
 
+## Course Users Passed List [/courses/{course_id}/users/passed]
+
+It allows clients to interact with the Course passing Users
+
+### Course Users Passed List [GET]
+
+Returns a list of user ids of course passing users
+
+
++ Response 200 (application/json)
+
+        [2,10,18,19,33,66]
+
+
 # Group Groups
 Resources related to groups in the API.
 


### PR DESCRIPTION
This PR documents API required for building certificates at Apros. Apros admin will call this API documented in this PR on course end date to get list of all passing participants for the specified course and generate certificates for those users on apros side.