### PR TITLE
YONK-692: return user's profile images instead of avatar_url in APIs

### DIFF
--- a/edx_solutions_api_integration/courses/tests.py
+++ b/edx_solutions_api_integration/courses/tests.py
@@ -247,7 +247,6 @@ class CoursesApiTests(
         for user in cls.users:
             CourseEnrollmentFactory.create(user=user, course_id=cls.course.id)
             user_profile = user.profile
-            user_profile.avatar_url = 'http://example.com/{}.png'.format(user.id)
             user_profile.title = 'Software Engineer {}'.format(user.id)
             user_profile.city = 'Cambridge'
             user_profile.save()
@@ -2494,7 +2493,7 @@ class CoursesApiTests(
                 'password': 'test.me!',
                 'first_name': '{} {}'.format('John', i), 'last_name': '{} {}'.format('Doe', i), 'city': city,
                 'country': 'PK', 'level_of_education': 'b', 'year_of_birth': '2000', 'gender': 'male',
-                'title': 'Software Engineer', 'avatar_url': 'http://example.com/avatar.png'
+                'title': 'Software Engineer'
             }
 
             response = self.do_post(test_uri, data)

--- a/edx_solutions_api_integration/courses/views.py
+++ b/edx_solutions_api_integration/courses/views.py
@@ -65,8 +65,7 @@ from edx_solutions_api_integration.models import (
 from progress.models import CourseModuleCompletion
 from social_engagement.models import StudentSocialEngagementScore
 from edx_solutions_api_integration.permissions import SecureAPIView, SecureListAPIView
-from edx_solutions_api_integration.users.serializers import UserSerializer, UserCountByCitySerializer, \
-    SimpleUserSerializer
+from edx_solutions_api_integration.users.serializers import UserSerializer, UserCountByCitySerializer
 from edx_solutions_api_integration.utils import (
     generate_base_uri,
     str2bool,
@@ -84,9 +83,9 @@ from edx_solutions_api_integration.utils import (
 from edx_solutions_api_integration.courses.serializers import (
     CourseSerializer,
     GradeSerializer,
-    CourseLeadersSerializer,
     CourseCompletionsLeadersSerializer,
     CourseSocialLeadersSerializer,
+    CourseProficiencyLeadersSerializer,
 )
 from progress.serializers import CourseModuleCompletionSerializer
 
@@ -1080,7 +1079,7 @@ class CoursesUsersList(SecureListAPIView):
             "last_name",
             "created",
             "is_active",
-            "avatar_url",
+            "profile_image",
             "city",
             "title",
             "country",
@@ -1855,7 +1854,7 @@ class CoursesMetricsGradesLeadersList(SecureListAPIView):
                                                                      count=count,
                                                                      exclude_users=exclude_users)
 
-            serializer = CourseLeadersSerializer(leaderboard_data['queryset'], many=True)
+            serializer = CourseProficiencyLeadersSerializer(leaderboard_data['queryset'], many=True)
             data['leaders'] = serializer.data  # pylint: disable=E1101
             data['course_avg'] = leaderboard_data['course_avg']
             if 'user_position' in leaderboard_data:

--- a/edx_solutions_api_integration/users/serializers.py
+++ b/edx_solutions_api_integration/users/serializers.py
@@ -6,6 +6,7 @@ from django.core.exceptions import ObjectDoesNotExist
 
 from edx_solutions_api_integration.models import APIUser
 from edx_solutions_organizations.serializers import BasicOrganizationSerializer
+from edx_solutions_api_integration.utils import get_profile_image_urls_by_username
 from student.roles import CourseAccessRole
 
 
@@ -37,7 +38,7 @@ class UserSerializer(DynamicFieldsModelSerializer):
     """ Serializer for User model interactions """
     organizations = BasicOrganizationSerializer(many=True, required=False)
     created = serializers.DateTimeField(source='date_joined', required=False)
-    avatar_url = serializers.CharField(source='profile.avatar_url')
+    profile_image = serializers.SerializerMethodField()
     city = serializers.CharField(source='profile.city')
     title = serializers.CharField(source='profile.title')
     country = serializers.CharField(source='profile.country')
@@ -45,6 +46,16 @@ class UserSerializer(DynamicFieldsModelSerializer):
     courses_enrolled = serializers.SerializerMethodField()
     roles = serializers.SerializerMethodField('get_user_roles')
     grades = serializers.SerializerMethodField('get_user_grades')
+
+    def get_profile_image(self, user):
+        """
+        Returns metadata about a user's profile image
+        """
+        try:
+            profile_image_uploaded_at = user.profile.profile_image_uploaded_at
+        except ObjectDoesNotExist:
+            profile_image_uploaded_at = None
+        return get_profile_image_urls_by_username(user.username, profile_image_uploaded_at)
 
     def get_courses_enrolled(self, user):
         """ Serialize user enrolled courses """
@@ -100,7 +111,7 @@ class UserSerializer(DynamicFieldsModelSerializer):
             "last_name",
             "created",
             "is_active",
-            "avatar_url",
+            "profile_image",
             "city",
             "title",
             "country",

--- a/edx_solutions_api_integration/users/tests.py
+++ b/edx_solutions_api_integration/users/tests.py
@@ -222,7 +222,6 @@ class UsersApiTests(SignalDisconnectTestMixin, ModuleStoreTestCase, CacheIsolati
                 'password': self.test_password,
                 'first_name': 'John{}'.format(i),
                 'last_name': 'Doe{}'.format(i),
-                'avatar_url': 'http://avatar.com/{}.jpg'.format(i),
                 'city': 'Boston',
                 'title': "The King",
             }
@@ -287,10 +286,19 @@ class UsersApiTests(SignalDisconnectTestMixin, ModuleStoreTestCase, CacheIsolati
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 0)
         # add some additional fields and filter the response to only these fields
-        response = self.do_get('{}?email=test2@example.com&fields=avatar_url,city,title'.format(test_uri))
+        response = self.do_get('{}?email=test2@example.com&fields=profile_image,city,title'.format(test_uri))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['results']), 1)
-        self.assertEqual(response.data['results'][0]['avatar_url'], 'http://avatar.com/2.jpg')
+        self.assertEqual(
+            response.data['results'][0]['profile_image'],
+            {
+                'image_url_full': '/static/default_500.png',
+                'image_url_large': '/static/default_120.png',
+                'image_url_medium': '/static/default_50.png',
+                'image_url_small': '/static/default_30.png',
+                'has_image': False
+            }
+        )
         self.assertEqual(response.data['results'][0]['city'], 'Boston')
         self.assertEqual(response.data['results'][0]['title'], 'The King')
         if 'id' in response.data['results'][0]:
@@ -861,7 +869,7 @@ class UsersApiTests(SignalDisconnectTestMixin, ModuleStoreTestCase, CacheIsolati
             'email': self.test_email, 'username': local_username, 'password': self.test_password,
             'first_name': self.test_first_name, 'last_name': self.test_last_name, 'city': self.test_city,
             'country': 'PK', 'level_of_education': 'b', 'year_of_birth': '2000',
-            'gender': 'male', 'title': 'Software Engineer', 'avatar_url': 'http://example.com/avatar.png'
+            'gender': 'male', 'title': 'Software Engineer'
         }
         response = self.do_post(test_uri, data)
         self.assertEqual(response.status_code, 201)
@@ -891,7 +899,6 @@ class UsersApiTests(SignalDisconnectTestMixin, ModuleStoreTestCase, CacheIsolati
         """
         Create a user, then add the user profile with invalid year of birth
         Profile Must be added with year_of_birth will be none
-        and avatar_url None
         """
         test_uri = self.users_base_uri
         local_username = self.test_username + str(randint(11, 99))
@@ -899,7 +906,7 @@ class UsersApiTests(SignalDisconnectTestMixin, ModuleStoreTestCase, CacheIsolati
             'email': self.test_email, 'username': local_username, 'password': self.test_password,
             'first_name': self.test_first_name, 'last_name': self.test_last_name, 'city': self.test_city,
             'country': 'PK', 'level_of_education': 'b', 'year_of_birth': 'abcd',
-            'gender': 'male', 'title': 'Software Engineer', 'avatar_url': None
+            'gender': 'male', 'title': 'Software Engineer'
         }
         response = self.do_post(test_uri, data)
         self.assertEqual(response.status_code, 201)
@@ -1666,7 +1673,6 @@ class UsersApiTests(SignalDisconnectTestMixin, ModuleStoreTestCase, CacheIsolati
         self.assertEqual(response.data['country'], data["country"])
         self.assertEqual(response.data['gender'], data["gender"])
         self.assertEqual(response.data['title'], data["title"])
-        self.assertEqual(response.data['avatar_url'], data["avatar_url"])
         self.assertEqual(
             response.data['level_of_education'], data["level_of_education"])
         self.assertEqual(
@@ -1844,7 +1850,7 @@ class UsersApiTests(SignalDisconnectTestMixin, ModuleStoreTestCase, CacheIsolati
                 'password': self.test_password,
                 'first_name': self.test_first_name, 'last_name': self.test_last_name, 'city': city,
                 'country': 'PK', 'level_of_education': 'b', 'year_of_birth': '2000', 'gender': 'male',
-                'title': 'Software Engineer', 'avatar_url': 'http://example.com/avatar.png'
+                'title': 'Software Engineer'
             }
 
             response = self.do_post(test_uri, data)

--- a/edx_solutions_api_integration/users/views.py
+++ b/edx_solutions_api_integration/users/views.py
@@ -71,6 +71,7 @@ from edx_solutions_api_integration.utils import (
     extract_data_params,
     get_user_from_request_params,
     get_aggregate_exclusion_user_ids,
+    get_profile_image_urls_by_username,
     str2bool,
     css_param_to_list,
     get_aggregate_exclusion_user_ids,
@@ -99,8 +100,9 @@ def _serialize_user_profile(response_data, user_profile):
     response_data['level_of_education'] = user_profile.level_of_education
     response_data['year_of_birth'] = user_profile.year_of_birth
     response_data['gender'] = user_profile.gender
-    response_data['avatar_url'] = user_profile.avatar_url
-
+    response_data['profile_image'] = get_profile_image_urls_by_username(
+        response_data['username'], user_profile.profile_image_uploaded_at
+    )
     return response_data
 
 
@@ -264,7 +266,6 @@ class UsersList(SecureListAPIView):
         * level_of_education
         * year_of_birth, Four-digit integer value
         * gender, Single-character value (M/F)
-        * avatar_url, pointer to the avatar/image resource
     - POST Example:
 
             {
@@ -280,8 +281,7 @@ class UsersList(SecureListAPIView):
                 "country" : "US",
                 "level_of_education" : "hs",
                 "year_of_birth" : "1996",
-                "gender" : "F",
-                "avatar_url" : "http://example.com/avatar.png"
+                "gender" : "F"
             }
     ### Use Cases/Notes:
     * Password formatting policies can be enabled through the "ENFORCE_PASSWORD_POLICY" feature flag
@@ -372,7 +372,6 @@ class UsersList(SecureListAPIView):
         year_of_birth = request.data.get('year_of_birth', '')
         gender = request.data.get('gender', '')
         title = request.data.get('title', '')
-        avatar_url = request.data.get('avatar_url', None)
         # enforce password complexity as an optional feature
         if settings.FEATURES.get('ENFORCE_PASSWORD_POLICY', False):
             try:
@@ -422,7 +421,6 @@ class UsersList(SecureListAPIView):
         profile.level_of_education = level_of_education
         profile.gender = gender
         profile.title = title
-        profile.avatar_url = avatar_url
         profile.is_staff = is_staff
 
         try:
@@ -473,7 +471,6 @@ class UsersDetail(SecureAPIView):
         * level_of_education
         * year_of_birth, Four-digit integer value
         * gender, Single-character value (M/F)
-        * avatar_url, pointer to the avatar/image resource
     - POST Example:
 
             {
@@ -489,8 +486,7 @@ class UsersDetail(SecureAPIView):
                 "country" : "US",
                 "level_of_education" : "hs",
                 "year_of_birth" : "1996",
-                "gender" : "F",
-                "avatar_url" : "http://example.com/avatar.png"
+                "gender" : "F"
             }
     ### Use Cases/Notes:
     * Use the UsersDetail view to obtain the current state for a specific User


### PR DESCRIPTION
This PR has changes to return user's profile images instead of avatar_url in APIs which were returning `avatar_url`. This PR has changes to stop storing of `avatar_url` in user's profile model. [YONK-692](https://openedx.atlassian.net/browse/YONK-692) has details of requirements.
@aamishbaloch would you please review?