### PR TITLE
YONK-15: API optimisations using course blocks

### DIFF
--- a/edx_solutions_api_integration/courses/tests.py
+++ b/edx_solutions_api_integration/courses/tests.py
@@ -433,12 +433,11 @@ class CoursesApiTests(
         self.assertEqual(response.data['end'], create_course_with_out_date_values.end)
 
     def test_courses_detail_get(self):
-        test_course_usage_key = unicode(modulestore().make_course_usage_key(self.course.id))
         test_uri = self.base_courses_uri + '/' + self.test_course_id
         response = self.do_get(test_uri)
         self.assertEqual(response.status_code, 200)
         self.assertGreater(len(response.data), 0)
-        self.assertEqual(response.data['id'], test_course_usage_key)
+        self.assertEqual(response.data['id'], self.test_course_id)
         self.assertEqual(response.data['name'], self.test_course_name)
         self.assertEqual(
             datetime.strftime(response.data['start'], '%Y-%m-%d %H:%M:%S'),
@@ -454,7 +453,6 @@ class CoursesApiTests(
         self.assertEqual(response.data['uri'], confirm_uri)
 
     def test_courses_detail_get_with_child_content(self):
-        test_course_usage_key = unicode(modulestore().make_course_usage_key(self.course.id))
         test_uri = self.base_courses_uri + '/' + self.test_course_id
         response = self.do_get('{}?depth=100'.format(test_uri))
         self.assertEqual(response.status_code, 200)

--- a/edx_solutions_api_integration/courses/views.py
+++ b/edx_solutions_api_integration/courses/views.py
@@ -238,7 +238,6 @@ def _make_block_tree(request, blocks_data, course_key, course_block, block=None,
 
             if data['category'] == 'course':
                 data['content'] = children
-                data['id'] = unicode(course_block.id)
             else:
                 data['children'] = children
 
@@ -247,6 +246,7 @@ def _make_block_tree(request, blocks_data, course_key, course_block, block=None,
             content_uri = '{}/{}'.format(base_content_uri, content_id)
             data['number'] = course_block.location.course
             data['org'] = course_block.location.org
+            data['id'] = unicode(course_block.id)
         else:
             content_uri = '{}/{}/content/{}'.format(base_content_uri, unicode(course_key), data['id'])
 


### PR DESCRIPTION
In case of Course (Parent), ID should be generated by course_block in _make_block_tree.