### PR TITLE
optimize course metrics and social metrics APIs

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1724,26 +1724,31 @@ Provides paginated list of course completions for a user. Use content_id paramet
         }
 
 
-## User Social Metrics [/users/{user_id}/courses/{course_id}/metrics/social]
+## User Social Metrics [/users/{user_id}/courses/{course_id}/metrics/social?include_stats=true]
 
 It allows clients to query about the activity of a user in the forums in the specified course
 
 ### User Social Metrics [GET]
 
-Returns a list of social metrics for that user in the specified course
+Returns social engagement score, course average engagement score and list of social metrics for that user in the specified course.
+To get only user's social engagement score and course average engagement score call this api with include_stats parameter.
 
 + Response 200 (application/json)
 
         {
-            "num_threads": 1,
-            "num_thread_followers": 0,
-            "num_replies": 0,
-            "num_flagged": 0,
-            "num_comments": 0,
-            "num_threads_read": 0,
-            "num_downvotes": 0,
-            "num_upvotes": 0,
-            "num_comments_generated": 0
+            "score": 40,
+            "course_avg": 10,
+            "stats": {
+                "num_threads": 1,
+                "num_thread_followers": 0,
+                "num_replies": 0,
+                "num_flagged": 0,
+                "num_comments": 0,
+                "num_threads_read": 0,
+                "num_downvotes": 0,
+                "num_upvotes": 0,
+                "num_comments_generated": 0
+            }
         }
 
 

--- a/edx_solutions_api_integration/courses/serializers.py
+++ b/edx_solutions_api_integration/courses/serializers.py
@@ -24,6 +24,16 @@ class CourseLeadersSerializer(serializers.Serializer):
     recorded = serializers.DateTimeField(source='modified')
 
 
+class CourseSocialLeadersSerializer(serializers.Serializer):
+    """ Serializer for course leaderboard """
+    id = serializers.IntegerField(source='user__id')  # pylint: disable=invalid-name
+    username = serializers.CharField(source='user__username')
+    title = serializers.CharField(source='user__profile__title')
+    avatar_url = serializers.CharField(source='user__profile__avatar_url')
+    score = serializers.IntegerField()
+    recorded = serializers.DateTimeField(source='modified')
+
+
 class CourseCompletionsLeadersSerializer(serializers.Serializer):
     """ Serializer for course completions leaderboard """
     id = serializers.IntegerField(source='user__id')  # pylint: disable=invalid-name

--- a/edx_solutions_api_integration/courses/urls.py
+++ b/edx_solutions_api_integration/courses/urls.py
@@ -47,6 +47,8 @@ urlpatterns = patterns(
         courses_views.CoursesMetricsGradesLeadersList.as_view(), name='course-metrics-grades-leaders'),
     url(r'^{0}/metrics/social/$'.format(COURSE_ID_PATTERN),
         courses_views.CoursesMetricsSocial.as_view(), name='courses-social-metrics'),
+    url(r'^{0}/metrics/social/leaders/*$'.format(COURSE_ID_PATTERN),
+        courses_views.CoursesMetricsSocialLeadersList.as_view(), name='course-metrics-social-leaders'),
     url(r'^{0}/roles/(?P<role>[a-z_]+)/users/(?P<user_id>[0-9]+)*$'.format(COURSE_ID_PATTERN),
         courses_views.CoursesRolesUsersDetail.as_view(), name='courses-roles-users-detail'),
     url(r'^{0}/roles/*$'.format(COURSE_ID_PATTERN),

--- a/edx_solutions_api_integration/migrations/0002_auto_20170412_0316.py
+++ b/edx_solutions_api_integration/migrations/0002_auto_20170412_0316.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def forwards_func(apps, schema_editor):
+    """
+    Creates index on city field of `auth_userprofile` table.
+    :param apps:
+    :param schema_editor:
+    :return:
+    """
+    schema_editor.execute("CREATE INDEX cities_index ON `auth_userprofile` (city(255)) USING BTREE;")
+
+
+def reverse_func(apps, schema_editor):
+    """
+    Removes index on city field of `auth_userprofile` table.
+    :param apps:
+    :param schema_editor:
+    :return:
+    """
+    schema_editor.execute("DROP INDEX cities_index on `auth_userprofile`;")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('edx_solutions_api_integration', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards_func, reverse_func),
+    ]

--- a/edx_solutions_api_integration/users/tests.py
+++ b/edx_solutions_api_integration/users/tests.py
@@ -33,6 +33,7 @@ from courseware.model_data import FieldDataCache
 from django_comment_common.models import Role, FORUM_ROLE_MODERATOR, ForumsConfig
 from instructor.access import allow_access
 from edx_solutions_organizations.models import Organization
+from social_engagement.models import StudentSocialEngagementScore
 from edx_solutions_projects.models import Project, Workgroup
 from edx_solutions_api_integration.test_utils import (
     get_non_atomic_database_settings,
@@ -1866,7 +1867,7 @@ class UsersApiTests(SignalDisconnectTestMixin, ModuleStoreTestCase, CacheIsolati
         self.assertEqual(response.data['results'][0]['count'], 6)
 
     def test_users_social_metrics_check_service_availability(self):
-        test_uri = '{}/{}/courses/{}/metrics/social/'.format(self.users_base_uri, self.user.id, self.course.id)
+        test_uri = '{}/{}/courses/{}/metrics/social/?include_stats=true'.format(self.users_base_uri, self.user.id, self.course.id)
         response = self.do_get(test_uri)
         self.assertEqual(response.status_code, 200)
 
@@ -1883,17 +1884,27 @@ class UsersApiTests(SignalDisconnectTestMixin, ModuleStoreTestCase, CacheIsolati
 
     @mock.patch("edx_solutions_api_integration.users.views.get_user_social_stats", _fake_get_user_social_stats)
     def test_users_social_metrics(self):
-        test_uri = '{}/{}/courses/{}/metrics/social/'.format(self.users_base_uri, self.user.id, self.course.id)
+        test_uri = '{}/{}/courses/{}/metrics/social/?include_stats=true'.format(
+            self.users_base_uri, self.user.id, self.course.id
+        )
         response = self.do_get(test_uri)
         self.assertEqual(response.status_code, 200)
 
     @mock.patch("edx_solutions_api_integration.users.views.get_user_social_stats", _fake_get_user_social_stats_with_end)
     def test_users_social_metrics_end_date(self):
+        user_score = 30
         course = CourseFactory.create(org='TUCGLG', run='TUCGLG1', end=datetime(2012, 1, 1))
-
-        test_uri = '{}/{}/courses/{}/metrics/social/'.format(self.users_base_uri, self.user.id, course.id)
+        CourseEnrollmentFactory(user=self.user, course_id=course.id)
+        StudentSocialEngagementScore.objects.get_or_create(
+            user=self.user, course_id=course.id, defaults={'score': user_score}
+        )
+        test_uri = '{}/{}/courses/{}/metrics/social/?include_stats=true'.format(
+            self.users_base_uri, self.user.id, course.id
+        )
         response = self.do_get(test_uri)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['score'], user_score)
+        self.assertEqual(response.data['course_avg'], user_score)
 
     def test_user_social_metrics_engagement_scores(self):
         other_user = UserFactory()
@@ -1912,7 +1923,7 @@ class UsersApiTests(SignalDisconnectTestMixin, ModuleStoreTestCase, CacheIsolati
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['score'], user_score.score)
-        self.assertEqual(response.data['course_avg_score'], course_avg_score)
+        self.assertEqual(response.data['course_avg'], course_avg_score)
 
     def test_users_roles_list_get(self):
         allow_access(self.course, self.user, 'staff')

--- a/edx_solutions_api_integration/utils.py
+++ b/edx_solutions_api_integration/utils.py
@@ -331,6 +331,20 @@ def get_ids_from_list_param(request, param_name):
     return ids
 
 
+def css_param_to_list(request, param_name):
+    """
+    Converst comma separated string parameter in a request to a list
+    :param request:
+    :param param_name:
+    :return: list of values in param
+    """
+    values = request.query_params.get(param_name, [])
+    if isinstance(values, basestring):
+        upper_bound = getattr(settings, 'API_LOOKUP_UPPER_BOUND', 100)
+        values = [value.strip() for value in filter(None, values.split(',')[:upper_bound])]
+    return values
+
+
 def strip_xblock_wrapper_div(html):
     """
     Removes xblock wrapper div from given html

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='1.0.9',
+    version='1.3.3',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
This PR has changes required to optimize course metrics and social metrics APIs. Changes also introduce a new CoursesMetricsSocialLeadersList view to get course leaders by their social engagement score.

Details of the implementation can be found in YONK-580.
@aamishbaloch could you please review?
