### PR TITLE
MCKIN-5478: add API key or OAuth2 authentication on user organizations API

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1612,13 +1612,16 @@ Removes the specified preference from the user's record
 + Response 204 (application/json)
 
 
-## User Organization List [/users/{user_id}/organizations]
+## User Organization List [/users/organizations/{?username}]
 
 It allows clients to retrieve a list of organizations a user belongs to
 
 ### User Organization List [GET]
 
 Returns a JSON representation of the paginated list of organizations for a user
+
++ Parameters
+    + username (required)
 
 + Response 200 (application/json)
 

--- a/edx_solutions_api_integration/permissions.py
+++ b/edx_solutions_api_integration/permissions.py
@@ -9,7 +9,9 @@ from rest_framework.response import Response
 
 from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
 from edx_solutions_api_integration.utils import (
-    get_client_ip_address, address_exists_in_network, str2bool,
+    str2bool,
+    get_client_ip_address,
+    address_exists_in_network,
     has_api_key_permission,
 )
 from edx_solutions_api_integration.models import APIUser as User

--- a/edx_solutions_api_integration/users/urls.py
+++ b/edx_solutions_api_integration/users/urls.py
@@ -38,7 +38,7 @@ urlpatterns = patterns(
         users_views.UsersPreferences.as_view(), name='users-preferences-list'),
     url(r'^(?P<user_id>[a-zA-Z0-9]+)/preferences/(?P<preference_id>[a-zA-Z0-9_]+)$',
         users_views.UsersPreferencesDetail.as_view(), name='users-preferences-detail'),
-    url(r'^(?P<user_id>[a-zA-Z0-9]+)/organizations/$',
+    url(r'^organizations/$',
         users_views.UsersOrganizationsList.as_view(), name='users-organizations-list'),
     url(r'^(?P<user_id>[a-zA-Z0-9]+)/roles/(?P<role>[a-z_]+)/courses/{0}$'.format(COURSE_ID_PATTERN),
         users_views.UsersRolesCoursesDetail.as_view(), name='users-roles-courses-detail'),

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='1.0.9',
+    version='2.0.0',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
This PR adds API key or OAuth2 authentication on user organizations API, `username` param is required if this endpoint is accessed using API key. In case of oauth2 if `username` is not given it will return organizations for authenticated user, If `username` is other than the authenticated user than that authenticated user must be staff user to get their organizations.