### PR TITLE
 MCKIN-5311: Implement mobile API for engagement.

### DIFF
--- a/edx_solutions_api_integration/mobile_api/tests/test_users.py
+++ b/edx_solutions_api_integration/mobile_api/tests/test_users.py
@@ -1,9 +1,11 @@
 """
 Tests for user related use cases in mobile APIs
 """
+import ddt
 from mobile_api.testutils import (
     MobileAPITestCase,
 )
+from student.tests.factories import UserFactory
 from edx_solutions_organizations.models import Organization
 
 
@@ -50,3 +52,83 @@ class TestUserOrganizationsApi(MobileAPITestCase):
         response = self.api_response(data={'username': self.user.username})
         self.assertEqual(response.data['count'], 1)
         self.assertEqual(response.data['results'][0]['display_name'], org_name)
+
+
+@ddt.ddt
+class TestUserDiscussionMetricsApi(MobileAPITestCase):
+    """
+    Tests for /api/server/mobile/v1/users/discussion_metrics/?username=<user_name>&course_id=<course_id>
+    """
+    REVERSE_INFO = {'name': 'mobile-users-discussion-metrics', 'params': {}}
+
+    def test_with_unauthenticated_user(self):
+        """
+        Tests scenario calling API when not authenticated user.
+        """
+        response = self.api_response(expected_response_code=None)
+        self.assertEqual(response.status_code, 401)
+
+    def test_with_invalid_course_id(self):
+        """
+        Test scenario when calling API without valid course_id.
+        """
+        self.login()
+
+        response = self.api_response(expected_response_code=None, data={'username': self.user.username})
+        self.assertEqual(response.status_code, 403)
+
+    @ddt.data(True, False)
+    def test_with_another_users_username(self, is_staff):
+        """
+        Test scenario when requested user and logged in user are not same.
+        """
+        other_user = UserFactory()
+
+        if is_staff:
+            self.user.is_staff = True
+            self.user.save()
+
+        self.login()
+
+        response = self.api_response(
+            expected_response_code=None,
+            data={'course_id': unicode(self.course.id), 'username': other_user.username}
+        )
+        if is_staff:
+            self.assertEqual(response.status_code, 200)
+        else:
+            self.assertEqual(response.status_code, 403)
+
+    @ddt.data(True, False)
+    def test_with_unenrolled_user(self, is_staff):
+        """
+        Test scenario when logged in user is not enrolled in the course.
+        """
+        if is_staff:
+            self.user.is_staff = True
+            self.user.save()
+
+        self.login()
+
+        response = self.api_response(
+            expected_response_code=None,
+            data={'course_id': unicode(self.course.id), 'username': self.user.username}
+        )
+
+        if is_staff:
+            self.assertEqual(response.status_code, 200)
+        else:
+            self.assertEqual(response.status_code, 403)
+
+    def test_with_enrolled_user(self):
+        """
+        Test scenario when logged in user is enrolled in the course.
+        """
+        self.login_and_enroll()
+
+        response = self.api_response(
+            expected_response_code=None,
+            data={'course_id': unicode(self.course.id), 'username': self.user.username}
+        )
+
+        self.assertEqual(response.status_code, 200)

--- a/edx_solutions_api_integration/mobile_api/urls.py
+++ b/edx_solutions_api_integration/mobile_api/urls.py
@@ -19,4 +19,6 @@ urlpatterns = patterns(
         name='mobile-courses-static-tabs-list'),
     url(r'^courses/{0}/static_tabs/(?P<tab_id>[a-zA-Z0-9_+\s\/:-]+)$'.format(COURSE_ID_PATTERN),
         mobile_views.MobileCoursesStaticTabsDetail.as_view(), name='mobile-courses-static-tabs-details'),
+    url(r'^users/discussion_metrics/',
+        mobile_views.MobileUsersDiscussionMetrics.as_view(), name='mobile-users-discussion-metrics'),
 )

--- a/edx_solutions_api_integration/mobile_api/views.py
+++ b/edx_solutions_api_integration/mobile_api/views.py
@@ -12,6 +12,7 @@ from edx_solutions_api_integration.permissions import (
     IsStaffOrEnrolled,
 )
 from edx_solutions_api_integration.users.views import (
+    UsersSocialMetrics,
     UsersOrganizationsList,
     UsersCourseProgressList,
     UsersCoursesDetail,
@@ -44,7 +45,7 @@ class MobileCoursesOverview(MobileSecureAPIView, CoursesOverview):
     """
 
     def __init__(self):
-        self.permission_classes += (IsStaffOrEnrolled, )
+        self.permission_classes += (IsStaffOrOwner, IsStaffOrEnrolled, )
 
 
 class MobileUsersCoursesDetail(MobileSecureAPIView, UsersCoursesDetail):
@@ -53,7 +54,7 @@ class MobileUsersCoursesDetail(MobileSecureAPIView, UsersCoursesDetail):
     """
 
     def __init__(self):
-        self.permission_classes += (IsStaffOrEnrolled, )
+        self.permission_classes += (IsStaffOrOwner, IsStaffOrEnrolled, )
 
 
 class MobileCoursesStaticTabsList(MobileSecureAPIView, CoursesStaticTabsList):
@@ -64,7 +65,7 @@ class MobileCoursesStaticTabsList(MobileSecureAPIView, CoursesStaticTabsList):
     """
 
     def __init__(self):
-        self.permission_classes += (IsStaffOrEnrolled, )
+        self.permission_classes += (IsStaffOrOwner, IsStaffOrEnrolled, )
 
 
 class MobileCoursesStaticTabsDetail(MobileSecureAPIView, CoursesStaticTabsDetail):
@@ -73,4 +74,13 @@ class MobileCoursesStaticTabsDetail(MobileSecureAPIView, CoursesStaticTabsDetail
     """
 
     def __init__(self):
-        self.permission_classes += (IsStaffOrEnrolled, )
+        self.permission_classes += (IsStaffOrOwner, IsStaffOrEnrolled, )
+
+
+class MobileUsersDiscussionMetrics(MobileSecureAPIView, UsersSocialMetrics):
+    """
+    View to return user discussion metrics and engagement score.
+    """
+
+    def __init__(self):
+        self.permission_classes += (IsStaffOrOwner, IsStaffOrEnrolled, )

--- a/edx_solutions_api_integration/permissions.py
+++ b/edx_solutions_api_integration/permissions.py
@@ -93,12 +93,11 @@ class IsStaffOrEnrolled(permissions.BasePermission):
     """
     def has_permission(self, request, view):
         user = request.user
-        course_id = request.parser_context.get('kwargs', {}).get('course_id', None)
+        course_id = request.GET.get('course_id') \
+                    or request.parser_context.get('kwargs', {}).get('course_id', None)
         course_key = get_course_key(course_id)
         if course_key:
-            return (user.is_staff or CourseEnrollment.is_enrolled(request.user, course_key)) \
-                    and (user.username == request.GET.get('username') or
-                         user.username == getattr(request, 'data', {}).get('username'))
+            return user.is_staff or CourseEnrollment.is_enrolled(request.user, course_key)
         return False
 
 


### PR DESCRIPTION
Implements mobile API with OAauth support for engagement. It also adds user's engagement score and course average engagement score to the API response.

It uses https://github.com/edx-solutions/discussion-edx-platform-extensions to fetch persisted engagement scores to avoid having to calculate course average score on-the-fly.

**JIRA tickets**: MCKIN-5311

**Dependencies**:

- https://github.com/edx-solutions/discussion-edx-platform-extensions/pull/10

**Testing instructions**:

1. Install code from https://github.com/edx-solutions/discussion-edx-platform-extensions/pull/10 into your virtual environment.
2. Enable https://github.com/edx-solutions/discussion-edx-platform-extensions on your devstack by adding `'ENABLE_SOCIAL_ENGAGEMENT': True` to your `FEATURES` in `lms.env.json`.
3. Verify that apros still successfully fetches engagement scores from the LMS (see that engagement graphs look correct on the course home page and course progress page). **NOTE**: If the social_engagement app was previously not enabled in your devstack, you will not have any persisted engagement scores. Currently there is no management command to recalculate engagement scores, so you'll have to perform some new activity in the forums in order for the score to be different from zero.
4. Set up OAuth client in LMS admin if you don't already have one set up.
4. Obtain OAuth access token for your test user: `curl -X POST -d "client_id={client_id}&client_secret={client_secret}&grant_type=password&username={username}&password={password}" https://lms.apros.local/oauth2/access_token/`
4. Verify that you can access the api with your OAuth access token: `curl 'http://lms.mcka.local/api/server/mobile/v1/users/discussion_metrics/?username={username}&course_id={course_id} -H 'Authorization: Bearer {access_token}' -v`

**Reviewers**
- [x] @bradenmacdonald 