### PR TITLE
prevent UsersCoursesDetail view from failing with 500

### DIFF
--- a/edx_solutions_api_integration/courses/views.py
+++ b/edx_solutions_api_integration/courses/views.py
@@ -572,9 +572,17 @@ class CoursesDetail(SecureAPIView):
         """
         GET /api/courses/{course_id}
         """
+        if 'username' in request.GET:
+            try:
+                user = User.objects.get(username=request.GET['username'])
+            except User.DoesNotExist:
+                raise Http404()
+        else:
+            user = request.user  # Usually this is AnonymousUser since this is a server-to-server API
+
         depth = request.query_params.get('depth', 0)
         depth_int = int(depth)
-        course_descriptor, course_key, course_content = get_course(request, request.user, course_id, depth=depth_int)  # pylint: disable=W0612
+        course_descriptor, course_key, course_content = get_course(request, user, course_id, depth=depth_int)  # pylint: disable=W0612
         if not course_descriptor:
             return Response({}, status=status.HTTP_404_NOT_FOUND)
 
@@ -584,6 +592,7 @@ class CoursesDetail(SecureAPIView):
             data_blocks = get_blocks(
                 request,
                 usage_key,
+                user=user,
                 depth=depth_int,
                 requested_fields=BLOCK_DATA_FIELDS
             )

--- a/edx_solutions_api_integration/users/views.py
+++ b/edx_solutions_api_integration/users/views.py
@@ -57,7 +57,7 @@ from util.password_policy_validators import (
     validate_password_length, validate_password_complexity,
     validate_password_dictionary
 )
-from xmodule.modulestore import InvalidLocationError, EdxJSONEncoder
+from xmodule.modulestore import InvalidLocationError
 
 from progress.serializers import CourseModuleCompletionSerializer
 from edx_solutions_api_integration.courseware_access import get_course, get_course_child, get_course_key, course_exists
@@ -159,7 +159,7 @@ def _save_child_position(parent_descriptor, target_child_location):
     Faster version than what is in the LMS since we don't need to load/traverse children descriptors,
     we just compare id's from the array of children
     """
-    for position, child_location in enumerate(parent_descriptor.children, start=1):
+    for position, child_location in enumerate(getattr(parent_descriptor, 'children', []), start=1):
         if unicode(child_location) == unicode(target_child_location):
             # Only save if position changed
             if position != parent_descriptor.position:


### PR DESCRIPTION
Prevents LMS from raising 500 when queried for course content where a module may have no child content, and removes non-staff courses from module tree.

**JIRA tickets**: [OC-2999](https://tasks.opencraft.com/browse/OC-2999) [MCKIN-5434](https://edx-wiki.atlassian.net/browse/MCKIN-5434)

**Merge deadline**: None

**Testing instructions**:

1. Set up a course where a section is hidden from students (i.e. is staff-only content)
1. Log in as a non-staff user
1. The staff-only section is not visible in navigation, and if you navigate to the URL (that you can find before checking this branch out), it should 404 rather than 500.

**Author notes and concerns**:

Should I pass user along in the 2 other instances of `get_blocks()` in this file ([here](https://github.com/open-craft/api-integration/blob/a9f1e64509c731892efbd8849476355da939fc9e/edx_solutions_api_integration/courses/views.py#L361) and [here](https://github.com/open-craft/api-integration/blob/a9f1e64509c731892efbd8849476355da939fc9e/edx_solutions_api_integration/courses/views.py#L451))

**Reviewers**
- [ ] @bradenmacdonald 