### PR TITLE
WIP: allowed mobile apps access to CourseModuleCompletionList

### DIFF
--- a/edx_solutions_api_integration/mobile_api/urls.py
+++ b/edx_solutions_api_integration/mobile_api/urls.py
@@ -11,6 +11,8 @@ urlpatterns = patterns(
     url(r'^users/organizations/', mobile_views.MobileUsersOrganizationsList.as_view(), name='mobile-users-orgs-list'),
     url(r'^users/courses/progress', mobile_views.MobileUsersCourseProgressList.as_view(),
         name='mobile-users-courses-progress'),
+    url(r'^users/courses/{}/completion'.format(COURSE_ID_PATTERN),
+            mobile_views.MobileCourseModuleCompletion.as_view(), name='mobile-users-courses-completion'),
     url(r'^courses/{0}/overview'.format(COURSE_ID_PATTERN), mobile_views.MobileCoursesOverview.as_view(),
         name='mobile-courses-overview'),
     url(r'^users/courses/{0}'.format(COURSE_ID_PATTERN), mobile_views.MobileUsersCoursesDetail.as_view(),

--- a/edx_solutions_api_integration/mobile_api/views.py
+++ b/edx_solutions_api_integration/mobile_api/views.py
@@ -8,6 +8,7 @@ from edx_solutions_api_integration.courses.views import (
 )
 from edx_solutions_api_integration.permissions import (
     MobileListAPIView,
+    MobilePermissionMixin,
     MobileSecureAPIView,
     IsStaffOrEnrolled,
 )
@@ -16,6 +17,7 @@ from edx_solutions_api_integration.users.views import (
     UsersCourseProgressList,
     UsersCoursesDetail,
 )
+from edx_solutions_api_integration.courses.views import CourseModuleCompletionList
 from openedx.core.lib.api.permissions import IsStaffOrOwner
 
 
@@ -74,3 +76,9 @@ class MobileCoursesStaticTabsDetail(MobileSecureAPIView, CoursesStaticTabsDetail
 
     def __init__(self):
         self.permission_classes += (IsStaffOrEnrolled, )
+
+
+class MobileCourseModuleCompletion(MobilePermissionMixin, CourseModuleCompletionList, ):
+     """
+     Mimics CourseModuleCompletionList view but has mobile permissions.
+     """


### PR DESCRIPTION
As an interim solution before [this proposal](https://openedx.atlassian.net/wiki/spaces/OpenDev/pages/162247762/Completion+API) is completed, this PR allows mobile apps to modify completion state of arbitrary blocks.

**JIRA tickets**: Implements (OC-3058)[https://tasks.opencraft.com/browse/OC-3058] [MCKIN-5798](https://edx-wiki.atlassian.net/browse/MCKIN-5798)

**Merge deadline**: 2017-09-15

**Testing instructions**:
Will fill in soon

**Reviewers**
- [ ] @bradenmacdonald 
