### PR TITLE
Create view to create, activate, and enroll users for integration tests.

### DIFF
--- a/edx_solutions_api_integration/users/tests.py
+++ b/edx_solutions_api_integration/users/tests.py
@@ -2252,7 +2252,11 @@ class UsersApiTests(SignalDisconnectTestMixin, ModuleStoreTestCase, CacheIsolati
             'email': self.test_email,
             'username': self.test_username,
             'password': self.test_password,
-            'courses': [six.text_type(self.course.id), 'course-v1:non+existent+course'],
+            'courses': [
+                six.text_type(self.course.id),
+                'course-v1:non+existent+course',
+                'course-v2:doesnt+exist',
+            ],
         }
         response = self.do_post('{}/integration-test-users/'.format(self.users_base_uri), data)
         self.assertEqual(response.status_code, 201)

--- a/edx_solutions_api_integration/users/urls.py
+++ b/edx_solutions_api_integration/users/urls.py
@@ -51,6 +51,6 @@ urlpatterns = patterns(
     url(r'/*$^', users_views.UsersList.as_view(), name='apimgr-users-list'),
     url(r'^(?P<user_id>[a-zA-Z0-9]+)/courses/progress',
         users_views.UsersCourseProgressList.as_view(), name='users-courses-progress'),
+    url(r'^integration-test-users/$', users_views.UsersListWithEnrollment.as_view(), name='integration-test-users'),
 )
-
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/edx_solutions_api_integration/users/views.py
+++ b/edx_solutions_api_integration/users/views.py
@@ -3,25 +3,26 @@
 import json
 import logging
 
-from requests.exceptions import ConnectionError
 from django.contrib.auth.models import Group
 from django.core.exceptions import ObjectDoesNotExist
+from django.core.validators import validate_email, validate_slug, ValidationError
 from django.db import IntegrityError
 from django.db.models import Count, Q
-from django.core.validators import validate_email, validate_slug, ValidationError
 from django.conf import settings
 from django.http import Http404
 from django.utils.translation import get_language, ugettext_lazy as _
-from rest_framework import status
+from requests.exceptions import ConnectionError
 from rest_framework import filters
 from rest_framework.response import Response
+from rest_framework import status
+import six
 
 from courseware import module_render
 from courseware.model_data import FieldDataCache
 from django_comment_common.models import Role, FORUM_ROLE_MODERATOR
 from gradebook.models import StudentGradebook
-from social_engagement.models import StudentSocialEngagementScore
 from gradebook.utils import generate_user_gradebook
+from social_engagement.models import StudentSocialEngagementScore
 from instructor.access import revoke_access, update_forum_role
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 from lms.lib.comment_client.utils import CommentClientRequestError, CommentClientMaintenanceError
@@ -43,7 +44,7 @@ from openedx.core.djangoapps.user_api.preferences.api import set_user_preference
 from edx_notifications.lib.consumer import mark_notification_read
 from course_metadata.models import CourseAggregatedMetaData
 from progress.models import StudentProgress
-from student.models import CourseEnrollment, PasswordHistory, UserProfile
+from student.models import CourseEnrollment, CourseEnrollmentException, PasswordHistory, UserProfile
 from student.roles import (
     CourseAccessRole,
     CourseInstructorRole,
@@ -1643,3 +1644,41 @@ class UsersCourseProgressList(SecureListAPIView):
         })
 
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+class UsersListWithEnrollment(UsersList):
+    """
+    View to create Users and enroll them in a list of courses.  In addition to
+    the options provided by UsersList.post, this view accepts an optional
+    "courses" attribute in the request body, which is a list of course keys to
+    enroll in.  
+    
+    The response will be annotated with a "courses" attribute which reflects
+    the list of courses the user was successfully enrolled in.  Failure to
+    enroll in a given course will not propagate an error to the caller, it will
+    just cause that course's key to be omitted from the response.
+    """
+
+    def post(self, request):
+        """
+        POST /api/users/integration_test_users/
+        """
+        AUDIT_LOG.warning(
+            "API::Creating and enrolling user with UsersListWithEnrollment. "
+            "This should not be used in production"
+        )
+        response = super(UsersListWithEnrollment, self).post(request)
+        if response.status_code == status.HTTP_201_CREATED:
+            user = User.objects.get(username=request.data['username'])
+            response.data['courses'] = []
+            course_key_gen = (CourseKey.from_string(course) for course in request.data['courses'])
+            for course_key in course_key_gen:
+                try: 
+                    CourseEnrollment.enroll(user=user, course_key=course_key, check_access=True)
+                except CourseEnrollmentException as exc:
+                    AUDIT_LOG.warning(
+                        "API::Could not enroll {} in {} because of {}".format(user, course_key, exc)
+                    )
+                else:
+                    response.data['courses'].append(six.text_type(course_key))
+        return response

--- a/edx_solutions_api_integration/users/views.py
+++ b/edx_solutions_api_integration/users/views.py
@@ -1679,7 +1679,7 @@ class UsersListWithEnrollment(UsersList):  # pylint: disable=too-many-ancestors
                     AUDIT_LOG.warning(
                         "API::Could not enroll %s in %s because of %s",
                         user,
-                        course_key,
+                        course_key_string,
                         exc
                     )
                 else:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='1.5.0',
+    version='1.4.2',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='1.4.1',
+    version='1.5.0',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',
@@ -12,7 +12,8 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        "django>=1.8",
+        'django>=1.8',
         'djangorestframework>=3.2.0',
+        'six',
     ],
 )


### PR DESCRIPTION
This creates a view that can be used by integration tests to create a user, active them, and enroll them in courses with a single API call.

## Reviewer
- [ ] @pomegranited 

## Test steps

* On a solutions devstack, update your `requirements/edx/custom.txt` to point to git+https://github.com/open-craft/api-integration.git@cliff/integration-test-user-creation#egg=api-integration==1.5.0a1`

* Post to /api/users/integration-test-users/ on solutions devstack with json post body:
```json
{
  "username": "unused_username", 
  "email": "email@address.com", 
  "password": "fourlettersormore",
  "courses": [
    "some/valid/courses",
    "course-v1:some+invalid",
    "course-v1:some+nonexistent+courses"
  ]
}
```

* If the user already exists or cannot be created for some other reason, an error should be returned. Otherwise the user should be created.  You should be able to log in as the user, and the user should be enrolled in the course as an audit user.

## Todo

- [ ] Merge
- [ ] Tag a new release (v1.5.0) (Note: I don't have permissions to do this)
- [ ] Create an PR on edx-solutions:edx-platform that uses v1.5.0.

## Refs
OC-3126
