### PR TITLE
YONK-778: Fix for error when user has not access to course blocks

### DIFF
--- a/edx_solutions_api_integration/courses/views.py
+++ b/edx_solutions_api_integration/courses/views.py
@@ -596,7 +596,14 @@ class CoursesDetail(SecureAPIView):
                 depth=depth_int,
                 requested_fields=BLOCK_DATA_FIELDS
             )
-            root_block = data_blocks['blocks'][data_blocks['root']]
+            root_block = data_blocks.get('blocks', {}).get(
+                data_blocks['root'],
+                {
+                    'id': unicode(course_descriptor.id),
+                    'display_name': course_descriptor.display_name,
+                    'type': course_descriptor.category
+                }
+            )
             response_data = _make_block_tree(
                 request,
                 data_blocks['blocks'],

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='1.4.0',
+    version='1.4.1',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
This PR has changes to fix `KeyError` when a user who has not access to course content try to call course details API. [YONK-778](https://openedx.atlassian.net/browse/YONK-778) has more details about the issue.
@aamishbaloch could you please review.