### PR TITLE
YONK-780: caching leaderboards for social, progress and proficiency metrics

### DIFF
--- a/edx_solutions_api_integration/utils.py
+++ b/edx_solutions_api_integration/utils.py
@@ -25,7 +25,7 @@ from openedx.core.djangoapps.user_api.accounts.serializers import PROFILE_IMAGE_
 from student.roles import CourseRole, CourseObserverRole
 
 USER_METRICS_CACHE_TTL = 60 * 60
-COURSE_METRICS_CACHE_TTL = 60 * 60
+COURSE_METRICS_CACHE_TTL = 30 * 60
 
 
 def address_exists_in_network(ip_address, net_n_bits):


### PR DESCRIPTION
This PR has changes to introduce caching of leader boards APIs for large cohort size courses. To test call these apis in django rest framework with django toolbar enabled twice and notice for second call SQL query are zero.

http://lms.mcka.local/api/server/courses/orgx/{course_id}/metrics/completions/leaders?count=3&user_id={user_id}

http://lms.mcka.local/api/server/courses/orgx/{course_id}/metrics/grades/leaders?count=3&user_id={user_id}

http://lms.mcka.local/api/server/courses/orgx/{course_id}/metrics/social/leaders?count=3&user_id={user_id}
@aamishbaloch could you please review