### PR TITLE
YONK-803: added group filter support in course groups API by multiple group types

### DIFF
--- a/edx_solutions_api_integration/courses/tests.py
+++ b/edx_solutions_api_integration/courses/tests.py
@@ -642,9 +642,10 @@ class CoursesApiTests(
     def test_courses_groups_list_get(self):
         test_uri = '{}/{}/groups'.format(self.base_courses_uri, self.test_course_id)
         course_fail_uri = '{}/{}/groups'.format(self.base_courses_uri, 'ed/Open_DemoX/edx_demo_course')
-        for i in xrange(2):
+        group_types = ['Programming', 'Programming', 'Calculus']
+        for i in range(len(group_types)):
             data_dict = {
-                'name': 'Alpha Group {}'.format(i), 'type': 'Programming',
+                'name': 'Alpha Group {}'.format(i), 'type': group_types[i],
             }
             response = self.do_post(self.base_groups_uri, data_dict)
             group_id = response.data['id']
@@ -652,14 +653,6 @@ class CoursesApiTests(
             self.assertEqual(response.status_code, 201)
             response = self.do_post(test_uri, data)
             self.assertEqual(response.status_code, 201)
-
-        data_dict['type'] = 'Calculus'
-        response = self.do_post(self.base_groups_uri, data_dict)
-        group_id = response.data['id']
-        data = {'group_id': group_id}
-        self.assertEqual(response.status_code, 201)
-        response = self.do_post(test_uri, data)
-        self.assertEqual(response.status_code, 201)
 
         response = self.do_get(test_uri)
         self.assertEqual(response.status_code, 200)
@@ -674,6 +667,12 @@ class CoursesApiTests(
         response = self.do_get(group_type_uri)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
+
+        # filter by more than one group type
+        group_type_uri = '{}?type={}'.format(test_uri, 'Calculus,Programming')
+        response = self.do_get(group_type_uri)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 3)
 
         error_group_type_uri = '{}?type={}'.format(test_uri, 'error_type')
         response = self.do_get(error_group_type_uri)

--- a/edx_solutions_api_integration/courses/views.py
+++ b/edx_solutions_api_integration/courses/views.py
@@ -674,6 +674,7 @@ class CoursesGroupsList(SecureAPIView):
     * Example: Display all of the courses for a particular academic series/program
     * If a relationship already exists between a Course and a particular group, the system returns 409 Conflict
     * The 'type' parameter filters groups by their 'group_type' field ('workgroup', 'series', etc.)
+    * The 'type' parameter can be a single value or comma separated list of values ('workgroup,series')
     """
 
     def post(self, request, course_id):
@@ -717,11 +718,11 @@ class CoursesGroupsList(SecureAPIView):
         """
         if not course_exists(request, request.user, course_id):
             return Response({}, status=status.HTTP_404_NOT_FOUND)
-        group_type = request.query_params.get('type', None)
+        group_type = css_param_to_list(request, 'type')
         course_key = get_course_key(course_id)
         course_groups = CourseGroupRelationship.objects.filter(course_id=course_key)
         if group_type:
-            course_groups = course_groups.filter(group__groupprofile__group_type=group_type)
+            course_groups = course_groups.filter(group__groupprofile__group_type__in=group_type)
         response_data = []
         group_profiles = GroupProfile.objects.filter(
             group_id__in=[course_group.group_id for course_group in course_groups]
@@ -1601,7 +1602,7 @@ class CoursesMetrics(SecureAPIView):
     - metrics can be filtered by organization by adding organization parameter to GET request
     - metrics_required param should be comma separated list of metrics required
     - possible values for metrics_required param are
-    - ``` users_started,modules_completed,users_completed,thread_stats,users_passed ```
+    - ``` users_started,modules_completed,users_completed,thread_stats,users_passed,avg_grade,avg_progress ```
     ### Use Cases/Notes:
     * Example: Display number of users enrolled in a given course
     """


### PR DESCRIPTION
This PR has changes to add group filter support in course groups API by multiple group types. The `type` parameter in course groups API can be a comma separated list of group types to filter.
@aamishbaloch could you please review? 