### PR TITLE
YONK-839: added mobile_available field to course serializer

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3801,7 +3801,7 @@ Returns groups in an organization, type parameter can be used to filter by group
         {}
 
 
-## Organization Courses List [/organizations/{organization_id}/courses/]
+## Organization Courses List [/organizations/{organization_id}/courses/?mobile_available=true|false]
 
 It allows clients to interact with a specific organization courses
 
@@ -3820,6 +3820,7 @@ Returns courses in an organization
                 "org": "edX",
                 "uri": "http://lms.mcka.local/api/server/courses/course-v1:edX+DemoX+Demo_Course",
                 "course_image_url": "/asset-v1:edX+DemoX+Demo_Course+type@asset+block@images_course_image.jpg",
+                "mobile_available": false,
                 "due": null,
                 "start": "2013-02-05T05:00:00Z",
                 "end": null,
@@ -3835,6 +3836,7 @@ Returns courses in an organization
                 "org": "edX",
                 "uri": "http://lms.mcka.local/api/server/courses/edX/CS301/2017_T1",
                 "course_image_url": "/c4x/edX/CS301/asset/images_course_image.jpg",
+                "mobile_available": true,
                 "due": null,
                 "start": "2017-01-01T00:00:00Z",
                 "end": null,

--- a/edx_solutions_api_integration/courses/serializers.py
+++ b/edx_solutions_api_integration/courses/serializers.py
@@ -68,6 +68,7 @@ class CourseSerializer(serializers.Serializer):
     org = serializers.CharField(source='display_org_with_default')
     uri = serializers.SerializerMethodField()
     course_image_url = serializers.SerializerMethodField()
+    mobile_available = serializers.BooleanField()
     due = serializers.SerializerMethodField('get_due_date')
     start = serializers.DateTimeField()
     end = serializers.DateTimeField()

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='1.5.8',
+    version='1.5.9',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
This PR adds `mobile_available` field to `CourseSerializer ` to support YONK-839.
@aamishbaloch could you please review?