### PR TITLE
YONK-837: Unnecessary data excluded in Organizations list API

### DIFF
--- a/edx_solutions_api_integration/mobile_api/serializers.py
+++ b/edx_solutions_api_integration/mobile_api/serializers.py
@@ -1,20 +1,21 @@
 from edx_solutions_organizations.models import Organization
-from mobileapps.serializers import MobileAppSerializer, ThemeSerializer
+from mobileapps.serializers import BasicMobileAppSerializer, BasicThemeSerializer
 from rest_framework import serializers
 from edx_solutions_organizations.serializers import BasicOrganizationSerializer
 
 
 class MobileOrganizationSerializer(BasicOrganizationSerializer):
     """ Serializer for Organization with mobile apps and themes data """
-    mobile_apps = MobileAppSerializer(many=True)
+    mobile_apps = BasicMobileAppSerializer(many=True)
     theme = serializers.SerializerMethodField()
 
     class Meta:
         model = Organization
-        fields = BasicOrganizationSerializer.Meta.fields + ('theme', 'mobile_apps')
+        fields = ('url', 'id', 'name', 'display_name', 'contact_name', 'contact_email', 'contact_phone',
+                  'created', 'modified', 'theme', 'mobile_apps')
 
     def get_theme(self, organization):
         theme = [theme for theme in organization.theme.all() if theme.active]
         if len(theme) > 0:
-            serializer = ThemeSerializer(theme[0])
+            serializer = BasicThemeSerializer(theme[0])
             return serializer.data

--- a/edx_solutions_api_integration/mobile_api/tests/test_users.py
+++ b/edx_solutions_api_integration/mobile_api/tests/test_users.py
@@ -115,6 +115,33 @@ class TestUserOrganizationsApi(MobileAPITestCase):
         self.assertEqual(response.data['results'][1]['mobile_apps'][0]['name'], 'Mobileapp 1')
         self.assertEqual(response.data['results'][1]['mobile_apps'][1]['name'], 'Mobileapp 2')
 
+    def test_mobileapps_data_in_organizations_list(self):
+        self.login()
+        organization1 = Organization.objects.create(display_name='ABC Organization')
+        organization1.users.add(self.user)
+
+        mobile_app1 = MobileApp.objects.create(name='Mobileapp 1', current_version='1.0', updated_by=self.user)
+        mobile_app1.organizations.add(organization1)
+
+        response = self.api_response(data={'username': self.user.username})
+        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(len(response.data['results']), 1)
+        self.assertEqual(response.data['num_pages'], 1)
+
+        self.assertEqual(response.data['results'][0]['display_name'], 'ABC Organization')
+        self.assertEqual(len(response.data['results'][0]['mobile_apps']), 1)
+        self.assertEqual(response.data['results'][0]['mobile_apps'][0]['name'], 'Mobileapp 1')
+
+        self.assertIn('ios_app_id', response.data['results'][0]['mobile_apps'][0])
+        self.assertIn('android_app_id', response.data['results'][0]['mobile_apps'][0])
+        self.assertIn('ios_download_url', response.data['results'][0]['mobile_apps'][0])
+        self.assertIn('android_download_url', response.data['results'][0]['mobile_apps'][0])
+        self.assertIn('deployment_mechanism', response.data['results'][0]['mobile_apps'][0])
+        self.assertIn('current_version', response.data['results'][0]['mobile_apps'][0])
+        self.assertIn('is_active', response.data['results'][0]['mobile_apps'][0])
+        self.assertNotIn('provider_key', response.data['results'][0]['mobile_apps'][0])
+        self.assertNotIn('provider_secret', response.data['results'][0]['mobile_apps'][0])
+
     def test_themes_in_organizations_list(self):
         self.login()
         organization1 = Organization.objects.create(display_name='ABC Organization')
@@ -141,6 +168,22 @@ class TestUserOrganizationsApi(MobileAPITestCase):
         self.assertEqual(response.data['results'][1]['theme']['name'], 'Theme 2')
         self.assertEqual(response.data['results'][1]['theme']['active'], True)
 
+    def test_themes_data_in_organizations_list(self):
+        self.login()
+        organization1 = Organization.objects.create(display_name='ABC Organization')
+        organization1.users.add(self.user)
+
+        Theme.objects.create(name='Theme 1', organization=organization1, active=True)
+
+        response = self.api_response(data={'username': self.user.username})
+        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(len(response.data['results']), 1)
+        self.assertEqual(response.data['num_pages'], 1)
+
+        self.assertEqual(response.data['results'][0]['display_name'], 'ABC Organization')
+        self.assertEqual(response.data['results'][0]['theme']['name'], 'Theme 1')
+        self.assertEqual(response.data['results'][0]['theme']['active'], True)
+        self.assertNotIn('organization', response.data['results'][0]['theme'])
 
 
 @ddt.ddt

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='1.6.0',
+    version='1.6.1',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
Changes include Basic Mobileapp and theme serializers added to exclude Organization & user data in mobile apps and themes details in Organizations list API.