### PR TITLE
[MCKIN-6668] Fix Mobile Progress Value

### DIFF
--- a/edx_solutions_api_integration/users/serializers.py
+++ b/edx_solutions_api_integration/users/serializers.py
@@ -178,6 +178,15 @@ class CourseProgressSerializer(serializers.Serializer):
     def get_progress(self, enrollment):
         completion_percentage = 0
 
+        # If this enrollment has a value from the new API, use that instead
+        # of calculating one. Note: Must multiply by 100 because its a ratio.
+        if enrollment['course_id'] in self.context['new_api_data']:
+            data_dict = self.context['new_api_data'][enrollment['course_id']]['completion']
+            earned = data_dict['earned']
+            possible = data_dict['possible']
+            completion_percentage = earned * 100.0 / possible
+            return completion_percentage
+
         actual_completions = next(
             (
                 progress['completions']

--- a/edx_solutions_api_integration/users/test_serializers.py
+++ b/edx_solutions_api_integration/users/test_serializers.py
@@ -1,0 +1,56 @@
+import ddt
+from datetime import datetime
+from django.test import TestCase
+from student.models import CourseEnrollment
+from edx_solutions_api_integration.users.serializers import CourseProgressSerializer
+
+
+@ddt.ddt
+class CourseProgressSerializerTests(TestCase):
+
+    @ddt.data(
+        (
+            # Values from the Newer API
+            'test_course_id',
+            {
+                'completion': {
+                    'earned': 3,
+                    'possible': 4
+                }
+            },
+            75.0
+        ),
+        (
+            # No Value from the Newer API
+            '', {}, 50.0
+        ),
+    )
+    @ddt.unpack
+    def test_get_progress(self, new_api_course_id, new_api_data, expected_progress):
+        course_id = 'test_course_id'
+        enrollment = {
+            'course_id': course_id,
+            'created': datetime.now(),
+            'is_active': True,
+            'progress': 0,
+        }
+        context = {
+            'new_api_data': {new_api_course_id: new_api_data},
+            'course_overview': [],
+            'student_progress': [
+                {
+                    'course_id': course_id,
+                    'completions': 1,
+                },
+            ],
+            'course_metadata': [
+                {
+                    'id': course_id,
+                    'total_assessments': 2
+                }
+            ]
+        }
+
+        serializer = CourseProgressSerializer(enrollment, context=context)
+        data = serializer.data
+        self.assertEqual(data['progress'], expected_progress)

--- a/edx_solutions_api_integration/users/views.py
+++ b/edx_solutions_api_integration/users/views.py
@@ -60,6 +60,7 @@ from util.password_policy_validators import (
 )
 from xmodule.modulestore import InvalidLocationError
 
+from completion_api.views import CompletionListView
 from progress.serializers import CourseModuleCompletionSerializer
 from edx_solutions_api_integration.courseware_access import get_course, get_course_child, get_course_key, course_exists
 from edx_solutions_api_integration.permissions import SecureAPIView, SecureListAPIView, IdsInFilterBackend, \
@@ -1643,7 +1644,16 @@ class UsersCourseProgressList(SecureListAPIView):
                 if enrollment['course_id'] in filtered_course_overview
             ]
 
+        # Calling the new API to get the progress.
+        view = CompletionListView()
+        view.request = request
+        result = view.get(request)
+        new_api_data = {}
+        for obj in result.data['results']:
+            new_api_data[obj['course_key']] = obj
+
         serializer = CourseProgressSerializer(enrollments, many=True, context={
+            'new_api_data': new_api_data,
             'student_progress': student_progress,
             'course_overview': course_overview,
             'course_metadata': course_meta_data,


### PR DESCRIPTION
This pull request makes sure that the Progress value of the old API is the same as the new API.

**JIRA tickets**: MCKIN-6668

**Merge deadline**: "None"

**Testing instructions**:

1. For at least one course, inside Studio, set "Mobile Course Available" to "true" in Advanced Settings
2. Log into the Staff user.
3. Visit this course with the staff user in LMS and incur progress events.
4. Visit the URL /api/server/mobile/v1/users/courses/progress?username=staff 
5. Examine the "progress" value for each progress event.
6. Visit the URL /api/completion/v0/course/?mobile_only=true
7. Compare the "ratio" values with the "progress" values of the other API. The progress value should be 100x larger than the ratio value.

**Author notes and concerns**:

1. The way this fix works, is the new API is called and the progress value is set instead of calculating it.

**Reviewers**
- [ ] @jcdyer 
- [ ] @mtyaka 