### PR TITLE
YONK-927: OrganizationCourseSerializer updated

### DIFF
--- a/edx_solutions_api_integration/courses/serializers.py
+++ b/edx_solutions_api_integration/courses/serializers.py
@@ -101,11 +101,14 @@ class CourseSerializer(serializers.Serializer):
 class OrganizationCourseSerializer(CourseSerializer):
     """ Serializer for Organization Courses """
     name = serializers.CharField(source='display_name')
-    enrolled_users = serializers.ListField(child=serializers.IntegerField())
+    enrolled_users = serializers.SerializerMethodField()
 
     class Meta(object):
         """ Serializer/field specification """
         fields = ('id', 'name', 'number', 'org', 'start', 'end', 'due', 'enrolled_users', )
+
+    def get_enrolled_users(self, obj):
+        return self.context['enrollments'][unicode(obj.id)]
 
 
 class UserGradebookSerializer(serializers.Serializer):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='1.7.1',
+    version='1.7.2',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
Changes include updating the OrganizationCourseSerializer that is used by Organization Courses API, to optimize the performance of the API. 

