### PR TITLE
Fix test_courses_completions_leaders test

### DIFF
--- a/edx_solutions_api_integration/courses/tests.py
+++ b/edx_solutions_api_integration/courses/tests.py
@@ -2051,7 +2051,8 @@ class CoursesApiTests(
         response = self.do_get(test_uri)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data['leaders']), 4)
-        self.assertEqual(response.data['position'], 2)
+        # Two users have the same completions, so position could be either 2 or 3
+        self.assertIn(response.data['position'], (2, 3))
         self.assertEqual('{0:.3f}'.format(response.data['completions']), '28.000')
 
         # with skipleaders filter

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='2.0.0',
+    version='2.0.1',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
The `test_courses_completions_leaders` test is failing because it's checking the completion position of a user and getting the wrong result. The position is based on the number of completions and the modified time, and there are two users with the same number of completions, so it's essentially relying on the modified time of the aggregator which isn't something the test should rely on. 