### PR TITLE
[MCKIN-8437] Restore /api/server/courses/{course_id}/completions view, using BlockCompletions.

### DIFF
--- a/edx_solutions_api_integration/courses/serializers.py
+++ b/edx_solutions_api_integration/courses/serializers.py
@@ -1,9 +1,11 @@
 """ Django REST Framework Serializers """
 from django.conf import settings
-from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
-from openedx.core.lib.courses import course_image_url
 from rest_framework import serializers
 from rest_framework.reverse import reverse
+
+from completion.models import BlockCompletion
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.core.lib.courses import course_image_url
 
 from edx_solutions_api_integration.utils import get_profile_image_urls_by_username
 
@@ -122,3 +124,25 @@ class UserGradebookSerializer(serializers.Serializer):
         if gradebook.grade and (gradebook.proforma_grade <= gradebook.grade + grade_complete_match_range):
             complete_status = True
         return complete_status
+
+
+class BlockCompletionSerializer(serializers.ModelSerializer):
+    """
+    Serialize Block Completions.
+
+    Include extra fields for backwards compatibility with CourseModuleCompletions.
+    """
+
+    class Meta(object):  # pylint: disable=missing-docstring,too-few-public-methods
+        model = BlockCompletion
+
+    user_id = serializers.IntegerField(source='user.id')
+    content_id = serializers.CharField(source='block_key')
+    course_id = serializers.CharField(source='course_key')
+    stage = serializers.SerializerMethodField()
+
+    def get_stage(self, _obj):  # pylint: disable=no-self-use
+        """
+        BlockCompletions do not support stages.  Always return None.
+        """
+        return None

--- a/edx_solutions_api_integration/courses/urls.py
+++ b/edx_solutions_api_integration/courses/urls.py
@@ -28,6 +28,8 @@ urlpatterns = patterns(
     url(r'^{0}/groups/(?P<group_id>[0-9]+)$'.format(COURSE_ID_PATTERN), courses_views.CoursesGroupsDetail.as_view()),
     url(r'^{0}/groups/*$'.format(COURSE_ID_PATTERN), courses_views.CoursesGroupsList.as_view()),
     url(r'^{0}/overview/*$'.format(COURSE_ID_PATTERN), courses_views.CoursesOverview.as_view()),
+    url(r'^{0}/completions/*$'.format(COURSE_ID_PATTERN),
+        courses_views.CompletionList.as_view(), name='completion-list'),
     url(r'^{0}/static_tabs/(?P<tab_id>[a-zA-Z0-9_+\s\/:-]+)$'.format(COURSE_ID_PATTERN),
         courses_views.CoursesStaticTabsDetail.as_view()),
     url(r'^{0}/static_tabs/*$'.format(COURSE_ID_PATTERN), courses_views.CoursesStaticTabsList.as_view()),


### PR DESCRIPTION
Implements an endpoint that was mistakenly removed, but required for group-project-v2.  The endpoint previously used CourseModuleCompletions as its backing data, but now uses BlockCompletions.  The response format includes all the fields the endpoint previously included, but now also includes the data under the new names used by the completion api.

**JIRA tickets**: [MCKIN-8437](https://edx-wiki.atlassian.net/browse/MCKIN-8437) (partial fix), [BB-166](https://tasks.opencraft.com/browse/BB-166).

**Discussions**: N/A
**Dependencies**: N/A

**Screenshots**: N/A

**Sandbox URL**: N/A
**Merge deadline**: None

**Testing instructions**: 

1. Pip install this branch into a copy of the solutions devstack development branch.
2. Enable the waffle switch in the admin: completion.enable_completion_tracking.
3. Log in, register for the demo course, and navigate through the first few pages (spend at least five seconds on each page, and scroll all the way to the bottom, to ensure that completions get submitted).
4. Send a request to http://lms.mcka.local/api/server/courses/course-v1:edX+DemoX+Demo_Course/completions, specifying either ?content_id=<block_key> or ?user_id=<user_id> (or both, or neither).  Verify that useful results are returned.  

**Author notes and concerns**:

N/A

**Reviewers**
- [ ] @lgp171188 

**Settings**
N/A