### PR TITLE
Return the list of users' cohorts in the users in course api

### DIFF
--- a/edx_solutions_api_integration/courses/tests.py
+++ b/edx_solutions_api_integration/courses/tests.py
@@ -1299,6 +1299,19 @@ class CoursesApiTests(
         self.assertEqual(response.data['results'][0]['courses_enrolled'][0], unicode(course.id))
         self.assertEqual(response.data['results'][0]['courses_enrolled'][1], unicode(course2.id))
 
+    def test_courses_users_list_courses_course_groups_requested(self):
+        """Test the users list has the course groups information when explicitly requested."""
+        self.staff_login()
+        course = CourseFactory.create()
+        test_uri = self.base_courses_uri + '/{course_id}/users?additional_fields=course_groups'
+        user = UserFactory()
+
+        CourseEnrollmentFactory.create(user=user, course_id=course.id)
+        response = self.do_get(test_uri.format(course_id=unicode(course.id)))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['results']), 1)
+        self.assertIn('course_groups', response.data['results'][0])
+
     def test_courses_users_list_courses_passed(self):
         """ Test courses_passed value returned by courses users list api """
         course = self.setup_course_with_grading()

--- a/edx_solutions_api_integration/courses/views.py
+++ b/edx_solutions_api_integration/courses/views.py
@@ -1246,6 +1246,11 @@ class CoursesUsersList(MobileListAPIView):
                 'user_attributes'
             )
 
+        if 'course_groups' in additional_fields:
+            users = users.prefetch_related(
+                'course_groups'
+            )
+
         self.user_organizations = Organization.objects.filter(users__in=users).distinct()
         if orgs:
             self.user_organizations.filter(id__in=orgs).distinct()

--- a/edx_solutions_api_integration/users/serializers.py
+++ b/edx_solutions_api_integration/users/serializers.py
@@ -46,6 +46,21 @@ class UserSerializer(DynamicFieldsModelSerializer):
     roles = serializers.SerializerMethodField('get_user_roles')
     grades = serializers.SerializerMethodField('get_user_grades')
     attributes = serializers.SerializerMethodField('get_organization_attributes')
+    course_groups = serializers.SerializerMethodField('get_user_course_groups')
+
+
+    def get_user_course_groups(self, user):
+        """Return a list of course groups of the users, optionally filtered by course id."""
+
+        course_groups = user.course_groups.all()
+
+        if 'course_id' in self.context:
+            course_id = self.context['course_id']
+            course_groups = [group.name for group in course_groups if group.course_id == course_id]
+        else:
+            course_groups = [group.name for group in course_groups]
+
+        return course_groups
 
     def get_organization_attributes(self, user):
         """
@@ -137,6 +152,7 @@ class UserSerializer(DynamicFieldsModelSerializer):
             "roles",
             "grades",
             "attributes",
+            "course_groups",
         )
         read_only_fields = ("id", "email", "username")
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='2.0.7',
+    version='2.0.8',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
Implements the changes to return the list of users' cohorts in the course API, controlled by the `additional_fields` querystring parameter.

**JIRA Tickets**: [MCKIN-8491](https://edx-wiki.atlassian.net/browse/MCKIN-8491)

**Discussions**: N/A
**Dependencies**: N/A

**Screenshots**: N/A

**Sandbox URL**: N/A
**Merge deadline**: 15 Oct 2018
**Testing instructions**: 
* Install the source branch of this PR in the `edx-solutions` devstack in the `edxapp` virtualenv.
* From the Apros Django shell, invoke the `get_course_details_users` method in the `api_client/course_api.py` file with the `additional_fields` querystring parameter having the value `course_groups`. The returned response should have a list of containing the users' cohort group for the given course.

**Reviewers**
- [ ] @UmanShahzad 