### PR TITLE
Update version to 2.0.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='2.0.8',
+    version='2.0.9',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
This updates the version in `setup.py` to 2.0.9, in order to tag and release the changes in https://github.com/edx-solutions/api-integration/pull/155.

I had updated the version from 2.0.7 to 2.0.8 in that PR. But there was already a tagged 2.0.8 release without an updated `setup.py`

**Reviewers**
- [ ] @UmanShahzad 