### PR TITLE
Revert "[MCKIN-8714] Disable caching social metrics"

### DIFF
--- a/edx_solutions_api_integration/users/views.py
+++ b/edx_solutions_api_integration/users/views.py
@@ -1409,12 +1409,23 @@ class UsersSocialMetrics(SecureListAPIView):
             raise Http404
 
         course_key = get_course_key(course_id)
-        social_engagement_score = self._get_user_score(course_key, user)
-        course_avg = self._get_course_average_score(course_key)
-        data = {'course_avg': course_avg, 'score': social_engagement_score}
+        cached_social_data = get_cached_data('social', course_id, user.id)
+        if not cached_social_data:
+            social_engagement_score = self._get_user_score(course_key, user)
+            course_avg = self._get_course_average_score(course_key)
+            data = {'course_avg': course_avg, 'score': social_engagement_score}
+            cache_course_data('social', course_id, {'course_avg': course_avg})
+            cache_course_user_data('social', course_id, user.id, {'score': social_engagement_score})
+        else:
+            data = cached_social_data
 
         if include_stats:
-            data['stats'] = StudentSocialEngagementScore.get_user_engagements_stats(course_key, user.id)
+            if not data.get('stats'):
+                data['stats'] = StudentSocialEngagementScore.get_user_engagements_stats(course_key, user.id)
+                cache_course_user_data('social', course_id, user.id, {'score': data['score'], 'stats': data['stats']})
+        else:
+            # In case it was cached.
+            data.pop('stats', None)
 
         return Response(data, status.HTTP_200_OK)
 

--- a/edx_solutions_api_integration/users/views.py
+++ b/edx_solutions_api_integration/users/views.py
@@ -1420,12 +1420,7 @@ class UsersSocialMetrics(SecureListAPIView):
             data = cached_social_data
 
         if include_stats:
-            if not data.get('stats'):
-                data['stats'] = StudentSocialEngagementScore.get_user_engagements_stats(course_key, user.id)
-                cache_course_user_data('social', course_id, user.id, {'score': data['score'], 'stats': data['stats']})
-        else:
-            # In case it was cached.
-            data.pop('stats', None)
+            data['stats'] = StudentSocialEngagementScore.get_user_engagements_stats(course_key, user.id)
 
         return Response(data, status.HTTP_200_OK)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='2.2.0',
+    version='2.2.2',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='2.2.1',
+    version='2.2.0',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
Reverts edx-solutions/api-integration#161 and part of #151.

**Testing instructions**:
1. Send
```bash
curl -X GET \
  'http://localhost:8000/api/server/users/{user_id}/courses/{course_id}/metrics/social/?include_stats=true' \
  -H 'X-Edx-Api-Key: edx_api_key'
```
with and without `include_stats` query param and verify it's working.