### PR TITLE
[MCKIN-8891] Optimize CourseMetricsLeaders

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='2.3.5',
+    version='2.3.6',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
This optimizes `CourseMetricsLeaders.get` by gathering leaders with a `ThreadPool`.
The processing time for this view went down from around 250ms to 50ms on my local environment.

## Testing instructions:
### Preparations:
- Prepare course with some social engagement/progress/proficiency stats (one of them is sufficient in this case, because this PR does not modify the logic).
- Prepare user's token

### Request
```bash
curl -X GET \
       http://{LMS}/api/server/courses/{course_id}/metrics/leaders/ \
       -H 'Authorization: Bearer {token}' \
       -H 'X-Edx-Api-Key: edx_api_key' \
       -H 'cache-control: no-cache' \
       -o /dev/null \
       -sw 'Total: %{time_total}s\n'
```

### Testing
- Stay with `api-integration:master`, make the request multiple times and get average time from it.
- Checkout to this branch and repeat making the request and getting average time.
- You can also check if it's working by logging as user and going to `Cohort` site.

## Issues
Unfortunately using `ThreadPool` will not work with `django-silk`. There is already [an issue](https://github.com/jazzband/django-silk/issues/169) about it, but it looks like there is no progress on it, so it's something that needs to be kept in mind. This will only affect `CourseMetricsLeaders.get` view.