### PR TITLE
[MCKIN-8963] Optimize CoursesRolesList.get

### DIFF
--- a/edx_solutions_api_integration/courses/views.py
+++ b/edx_solutions_api_integration/courses/views.py
@@ -2390,11 +2390,11 @@ class CoursesRolesList(SecureAPIView):
         assistants = CourseAssistantRole(course_key).users_with_role()
         all_users = (instructors | staff | observers | assistants).annotate(role=F("courseaccessrole__role"))
         if user_id:
-            all_users &= User.objects.filter(id=int(user_id))
+            all_users = all_users.filter(id=int(user_id))
         if role:
-            all_users &= User.objects.filter(courseaccessrole__role=role)
+            all_users = all_users.filter(role=role)
         return Response(
-            all_users.values("id", "role"),
+            all_users.distinct().values("id", "role"),
             status=status.HTTP_200_OK
         )
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='2.3.6',
+    version='2.3.7',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
The API was making at least 4 DB calls to get data from the same User table, and then doing for loops over all that data up to 3 times to populate a list and filter things down.

This kills the for loop and makes 1 DB call.

Test instructions:

1. Start up the LMS.
1. Do this before and after going onto this branch, and compare the times and outputs. (Remove the `-o` flag and its value to see output).
    ```bash
    curl -X GET \
           http://lms.mcka.local/api/server/courses/course-v1:edX%2BDemoX%2BDemo_Course/roles/ \
           -H 'Authorization: Bearer <token>' \
           -H 'X-Edx-Api-Key: edx_api_key' \
           -H 'cache-control: no-cache' \
           -o /dev/null \
           -sw 'Total: %{time_total}s\n'
    ```
1. Make sure the resulting list is the same (though order may differ), but that the time taken is less. You can also just use silk.
1. Finally, add a query param like `user_id=2` or `role=assistant` and make sure the returned list was filtered appropriately.

My own testing gave this, where the above is the old version, and the bottom is the new:

![selection_002](https://user-images.githubusercontent.com/10018065/49137154-6e923480-f30d-11e8-8ec6-d1bbdf4e3947.jpg)
