### PR TITLE
Remove the lockout after I reset my password

### DIFF
--- a/edx_solutions_api_integration/users/views.py
+++ b/edx_solutions_api_integration/users/views.py
@@ -41,7 +41,7 @@ from openedx.core.djangoapps.user_api.preferences.api import set_user_preference
 from edx_notifications.lib.consumer import mark_notification_read
 from course_metadata.models import CourseAggregatedMetaData, CourseSetting
 from completion_aggregator.models import Aggregator
-from student.models import CourseEnrollment, CourseEnrollmentException, PasswordHistory, UserProfile
+from student.models import CourseEnrollment, CourseEnrollmentException, PasswordHistory, UserProfile, LoginFailures
 from student.roles import (
     CourseAccessRole,
     CourseInstructorRole,
@@ -747,6 +747,10 @@ class UsersDetail(SecureAPIView):
             existing_user.set_password(password)
             existing_user.save()
             update_user_password_hash = existing_user.password
+
+            # clear failed login attempts counters, if applicable
+            if LoginFailures.is_feature_enabled():
+                LoginFailures.clear_lockout_counter(existing_user)
 
             if update_user_password_hash != old_password_hash:
                 # add this account creation to password history

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='2.4.1',
+    version='2.4.2',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
**Story:**
The user is locked out after entering the incorrect password 3 times and was not able to get in for 30 minutes even when they try to reset their password, which is misleading.

**Ticket Criteria:**
If User is locked out and reset the password, the locked out is removed and he can log in with the new password.