### PR TITLE
MCKIN-9071: Fix manager reports view.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='2.4.5',
+    version='2.5.0',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
Allow filtering CoursesUsersList endpoint by users so we can make efficient queries for the manager dashboard.

**JIRA tickets**: MCKIN-9071

**Discussions**: See ticket.

**Dependencies**: None

**Screenshots**:

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: ?

**Testing instructions**:

1. Send a query to the CoursesUsersList endpoint providing a ?users=1,2,3 query param (where 1,2,3 are user ids that would otherwise be returned in the response).

**Author notes and concerns**:

This has the same potential to overrun the max URL size that we encountered in the competion-aggregator api, but we won't see this anytime soon in production, because no manager has more than 72 reports.  Currently, apros is restricting itself to requesting at most 100 user ids, so this won't cause a hard failure if the limit is exceeded.

**Reviewers**
- [ ] @xitij2000 


**Settings**
N/A