### PR TITLE
BB-742 Delete users using the new delete_user method

### DIFF
--- a/edx_solutions_api_integration/users/tests.py
+++ b/edx_solutions_api_integration/users/tests.py
@@ -2480,7 +2480,7 @@ class UsersApiTests(SignalDisconnectTestMixin, ModuleStoreTestCase, CacheIsolati
             CourseEnrollmentFactory.create(user=user, course_id=course2.id)
 
         # delete 1 user by id
-        response = self.do_delete('{}?ids={}'.format(test_uri, users[0]).id)
+        response = self.do_delete('{}?ids={}'.format(test_uri, users[0].id))
         self.assertEqual(response.status_code, 204)
         mock_delete_user.assert_called_once_with(users[0])
 

--- a/edx_solutions_api_integration/users/views.py
+++ b/edx_solutions_api_integration/users/views.py
@@ -91,8 +91,6 @@ from edx_solutions_api_integration.users.serializers import (
     UserRolesSerializer,
     CourseProgressSerializer,
 )
-from lms.lib.comment_client.user import User as CCUser
-from lms.lib.comment_client.utils import CommentClientRequestError
 
 log = logging.getLogger(__name__)
 AUDIT_LOG = logging.getLogger("audit")
@@ -393,14 +391,9 @@ class UsersList(SecureListAPIView):
         """
         # require at least either ids or username filters
         if set(self.request.query_params.keys()) & set(['username', 'ids']):
-            qs =self.filter_queryset(self.queryset)
+            qs = self.filter_queryset(self.queryset)
             for user in qs:
-                try:
-                    delete_user(user)
-                except CommentClientRequestError as e:
-                    # Proceed if discussion user does not exist
-                    if e.message != u'{"message":"User not found."}':
-                        raise
+                delete_user(user)
             return Response({}, status.HTTP_204_NO_CONTENT)
         else:
             return Response({'message': _('username or ids are missing')}, status.HTTP_400_BAD_REQUEST)

--- a/edx_solutions_api_integration/users/views.py
+++ b/edx_solutions_api_integration/users/views.py
@@ -37,7 +37,7 @@ from openedx.core.djangoapps.course_groups.cohorts import (
     remove_user_from_cohort,
 )
 from openedx.core.djangoapps.user_api.models import UserPreference
-from openedx.core.djangoapps.user_api.accounts.api import delete_user
+from openedx.core.djangoapps.user_api.accounts.api import delete_users
 from openedx.core.djangoapps.user_api.preferences.api import set_user_preference
 from edx_notifications.lib.consumer import mark_notification_read
 from course_metadata.models import CourseAggregatedMetaData, CourseSetting
@@ -392,8 +392,7 @@ class UsersList(SecureListAPIView):
         # require at least either ids or username filters
         if set(self.request.query_params.keys()) & set(['username', 'ids']):
             qs = self.filter_queryset(self.queryset)
-            for user in qs:
-                delete_user(user)
+            delete_users(qs)
             return Response({}, status.HTTP_204_NO_CONTENT)
         else:
             return Response({'message': _('username or ids are missing')}, status.HTTP_400_BAD_REQUEST)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='2.5.5',
+    version='2.5.6',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
https://github.com/edx-solutions/edx-platform/pull/1359 introduces a new api method for deleting users and other related records.

This PR updates the DELETE api introduced from #188 to use the new method from https://github.com/edx-solutions/edx-platform/pull/1359. 

Example usage is unchanged from #188 
```
DELETE /api/users?ids=23
DELETE /api/users?ids=23,24,25
DELETE /api/users?username=edx
```