### PR TITLE
MCKIN-9466: adds course engagement summary api

### DIFF
--- a/edx_solutions_api_integration/courses/urls.py
+++ b/edx_solutions_api_integration/courses/urls.py
@@ -58,7 +58,7 @@ urlpatterns = patterns(
     url(r'^{0}/updates/*$'.format(COURSE_ID_PATTERN), courses_views.CoursesUpdates.as_view()),
     url(r'^{0}/users/(?P<user_id>[0-9]+)$'.format(COURSE_ID_PATTERN), courses_views.CoursesUsersDetail.as_view()),
     url(r'^{0}/users/*$'.format(COURSE_ID_PATTERN), courses_views.CoursesUsersList.as_view()),
-    url(r'^{0}/engagement-summary/*$'.format(COURSE_ID_PATTERN), courses_views.CoursesEngagementSummary.as_view()),
+    url(r'^{0}/engagement_summary/*$'.format(COURSE_ID_PATTERN), courses_views.CoursesEngagementSummary.as_view()),
     url(r'^{0}/users/passed$'.format(COURSE_ID_PATTERN), courses_views.CoursesUsersPassedList.as_view()),
     url(r'^{0}/workgroups/*$'.format(COURSE_ID_PATTERN), courses_views.CoursesWorkgroupsList.as_view()),
     url(r'^{0}/navigation/{1}$'.format(COURSE_ID_PATTERN, settings.USAGE_KEY_PATTERN),

--- a/edx_solutions_api_integration/courses/urls.py
+++ b/edx_solutions_api_integration/courses/urls.py
@@ -58,6 +58,7 @@ urlpatterns = patterns(
     url(r'^{0}/updates/*$'.format(COURSE_ID_PATTERN), courses_views.CoursesUpdates.as_view()),
     url(r'^{0}/users/(?P<user_id>[0-9]+)$'.format(COURSE_ID_PATTERN), courses_views.CoursesUsersDetail.as_view()),
     url(r'^{0}/users/*$'.format(COURSE_ID_PATTERN), courses_views.CoursesUsersList.as_view()),
+    url(r'^{0}/engagement-summary/*$'.format(COURSE_ID_PATTERN), courses_views.CoursesEngagementSummary.as_view()),
     url(r'^{0}/users/passed$'.format(COURSE_ID_PATTERN), courses_views.CoursesUsersPassedList.as_view()),
     url(r'^{0}/workgroups/*$'.format(COURSE_ID_PATTERN), courses_views.CoursesWorkgroupsList.as_view()),
     url(r'^{0}/navigation/{1}$'.format(COURSE_ID_PATTERN, settings.USAGE_KEY_PATTERN),

--- a/edx_solutions_api_integration/courses/utils.py
+++ b/edx_solutions_api_integration/courses/utils.py
@@ -2,7 +2,7 @@ from completion_aggregator.models import Aggregator
 from django.db.models import Q, Sum, Avg
 
 
-def _get_filtered_aggregation_queryset(course_key, **kwargs):
+def get_filtered_aggregation_queryset(course_key, **kwargs):
     queryset = Aggregator.objects.filter(
         course_key__exact=course_key,
         user__is_active=True,
@@ -59,7 +59,7 @@ def generate_leaderboard(course_key, **kwargs):
     ]
 
     """
-    queryset = _get_filtered_aggregation_queryset(course_key, **kwargs)
+    queryset = get_filtered_aggregation_queryset(course_key, **kwargs)
     queryset = queryset.values(
         'user__id',
         'user__username',
@@ -73,13 +73,13 @@ def generate_leaderboard(course_key, **kwargs):
 
 
 def get_total_completions(course_key, **kwargs):
-    queryset = _get_filtered_aggregation_queryset(course_key, **kwargs)
+    queryset = get_filtered_aggregation_queryset(course_key, **kwargs)
     aggregate = queryset.aggregate(earned=Sum('earned'), possible=Avg('possible'))
     return aggregate.get('earned'), aggregate.get('possible')
 
 
 def get_num_users_started(course_key, **kwargs):
-    queryset = _get_filtered_aggregation_queryset(course_key, **kwargs)
+    queryset = get_filtered_aggregation_queryset(course_key, **kwargs)
     return queryset.distinct().count()
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='2.5.0',
+    version='2.5.1',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
Currently to get course engagement summary call two APIs and performs calculations on response of those APIs which very slow for a large cohort set, This PR introduces a new API which returns calculated stats. Currently Engagement Summary took 43.24 seconds to load for a course with about 50k cohort, New API is taking 835.75 ms for the same course.

Testing Instructions:
Install this PR branch for api-integration in LMS.
Call `/api/server/courses/{course_id}/engagement-summary` with Bearer token.