### PR TITLE
[MCKIN-8918] Fix deleting user without discussion posts

### DIFF
--- a/edx_solutions_api_integration/users/views.py
+++ b/edx_solutions_api_integration/users/views.py
@@ -397,6 +397,7 @@ class UsersList(SecureListAPIView):
                 try:
                     CCUser.from_django_user(user).retire('Deleted username')
                 except CommentClientRequestError as e:
+                    # Proceed if discussion user does not exist
                     if e.message != u'{"message":"User not found."}':
                         raise
             qs.delete()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='2.5.3',
+    version='2.5.4',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
Description
=========

The discussion API fails when required to retire an user that doesn't exist on discussions yet. This can cause problems when deleting an user that have not accessed the discussion and this PR ignores this specific error when deleting an user.

Testing
--------

1. Create an user and immediately remove it, to make sure no discussion user is created.
2. The deletion proceeds without errors.