### PR TITLE
BB-849: Add check to assert that the comment deletion API was called

### DIFF
--- a/edx_solutions_api_integration/users/tests.py
+++ b/edx_solutions_api_integration/users/tests.py
@@ -2521,6 +2521,9 @@ class UsersApiTests(SignalDisconnectTestMixin, ModuleStoreTestCase, CacheIsolati
         self.assertEqual(response.status_code, 204)
         assert_delete_users_call_args(mock_delete_users, user_ids[10:15])
 
+        # Assert the correct number of calls has been made to CCUser
+        self.assertEqual(mock_user.from_django_user().retire.call_count, 15)
+
 
 @ddt.ddt
 class TokenBasedUsersApiTests(CacheIsolationTestCase, APIClientMixin, OAuth2TokenMixin):


### PR DESCRIPTION
Adds a test to check if the user comment deletion API was correctly called when deleting users.

**Testing instructions**:
1. Clone this repo, checkout this branch and install it on your solutions devstack with `pip install -e .`
2. Run tests with `paver test_system -s lms -t edx_solutions_api_integration`

**Reviewers:**
- [ ] @Agrendalath 