### PR TITLE
Remove debug trace statements

### DIFF
--- a/edx_solutions_api_integration/users/tests.py
+++ b/edx_solutions_api_integration/users/tests.py
@@ -2485,17 +2485,12 @@ class UsersApiTests(SignalDisconnectTestMixin, ModuleStoreTestCase, CacheIsolati
         self.assertEqual(response.status_code, 204)
 
         def assert_delete_users_call_args(mock, ids):
-            from nose.tools import set_trace
-            set_trace()
             call_args_ids = list(mock.call_args[0][0].values_list('id', flat=True))
             self.assertEqual(
                 call_args_ids,
                 ids
             )
         assert_delete_users_call_args(mock_delete_users, user_ids[:1])
-        from nose.tools import set_trace
-        set_trace()
-
 
         # delete multiple users by id
         mock_delete_users.reset_mock()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='2.5.6',
+    version='2.5.7',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
This removes the debug trace statements added accidentally in https://github.com/edx-solutions/api-integration/pull/197

@viadanna, do I have to bump the version for this change as well?