### PR TITLE
[MCKIN-7759] Remove usage of CourseAggregatedMetaData since it is no longer in use.

### DIFF
--- a/edx_solutions_api_integration/courses/tests.py
+++ b/edx_solutions_api_integration/courses/tests.py
@@ -52,8 +52,6 @@ from xmodule.modulestore.tests.django_utils import (
 )
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
-from course_metadata.models import CourseAggregatedMetaData
-
 from edx_solutions_api_integration.courseware_access import get_course_descriptor, get_course_key
 from edx_solutions_api_integration.test_utils import (
     APIClientMixin, CourseGradingMixin, SignalDisconnectTestMixin,
@@ -1592,9 +1590,6 @@ class CoursesApiTests(
         user_completions, course_total_assesments = 50, 100
 
         CourseEnrollmentFactory.create(user=user, course_id=course.id)
-        CourseAggregatedMetaData.objects.update_or_create(
-            id=course.id, defaults={'total_assessments': course_total_assesments}
-        )
         section_breakdown = [
             {
                 "category": "Homework",
@@ -2436,9 +2431,6 @@ class CoursesApiTests(
         self.login()
         users_to_add, user_grade, user_completions, total_assessments = 5, 0.6, 10, 20
         course = CourseFactory()
-        CourseAggregatedMetaData.objects.update_or_create(
-            id=course.id, defaults={'total_assessments': total_assessments}
-        )
         for idx in xrange(0, users_to_add):
             user = UserFactory()
             created_user_id = user.id

--- a/edx_solutions_api_integration/courses/views.py
+++ b/edx_solutions_api_integration/courses/views.py
@@ -25,7 +25,6 @@ from rest_framework.response import Response
 
 from completion.models import BlockCompletion
 from completion_aggregator.models import Aggregator
-from course_metadata.models import CourseAggregatedMetaData
 from courseware.courses import (
     get_course_about_section,
     get_course_info_section,
@@ -1208,7 +1207,6 @@ class CoursesUsersList(MobileListAPIView):
     """
     serializer_class = UserSerializer
     course_key = None
-    course_meta_data = None
     user_organizations = []
 
     def post(self, request, course_id):
@@ -1257,11 +1255,6 @@ class CoursesUsersList(MobileListAPIView):
         if not course_exists(course_id):
             return Response({}, status=status.HTTP_404_NOT_FOUND)
         self.course_key = get_course_key(course_id)
-        try:
-            self.course_meta_data = CourseAggregatedMetaData.objects.get(id=self.course_key)
-        except CourseAggregatedMetaData.DoesNotExist:
-            self.course_meta_data = None
-
         return super(CoursesUsersList, self).list(request)
 
     def get_serializer_context(self):
@@ -1294,7 +1287,6 @@ class CoursesUsersList(MobileListAPIView):
         serializer_context.update({
             'course_id': self.course_key,
             'default_fields': default_fields,
-            'course_meta_data': self.course_meta_data,
             'active_attributes': active_attributes,
         })
         return serializer_context

--- a/edx_solutions_api_integration/test_utils.py
+++ b/edx_solutions_api_integration/test_utils.py
@@ -20,9 +20,6 @@ from util.db import OuterAtomic
 from xmodule.modulestore.django import SignalHandler
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
-from course_metadata.signals import (
-    course_publish_handler_in_course_metadata as listener_in_course_metadata
-)
 from gradebook.signals import on_course_grade_changed
 
 
@@ -275,9 +272,6 @@ class SignalDisconnectTestMixin(object):
         """
         connects signals defined in solutions apps
         """
-        SignalHandler.course_published.connect(
-            listener_in_course_metadata, dispatch_uid='course_metadata'
-        )
         PROBLEM_WEIGHTED_SCORE_CHANGED.connect(on_course_grade_changed)
 
     @staticmethod
@@ -285,9 +279,6 @@ class SignalDisconnectTestMixin(object):
         """
         Disconnects signals defined in solutions apps
         """
-        SignalHandler.course_published.disconnect(
-            listener_in_course_metadata, dispatch_uid='course_metadata'
-        )
         PROBLEM_WEIGHTED_SCORE_CHANGED.disconnect(on_course_grade_changed)
 
 

--- a/edx_solutions_api_integration/urls.py
+++ b/edx_solutions_api_integration/urls.py
@@ -30,6 +30,8 @@ urlpatterns = patterns(
     url(r'^organizations/*', include('edx_solutions_organizations.urls')),
     url(r'^mobile/v1/', include('edx_solutions_api_integration.mobile_api.urls')),
     url(r'^imports/*', include('edx_solutions_api_integration.imports.urls')),
+    url(r'^courses_metadata/', include('course_metadata.urls')),
+
     # we have to explicitly define url for workgroup users detail view
     # to wrap it around non_atomic_requests decorator
     url(

--- a/edx_solutions_api_integration/urls.py
+++ b/edx_solutions_api_integration/urls.py
@@ -30,7 +30,6 @@ urlpatterns = patterns(
     url(r'^organizations/*', include('edx_solutions_organizations.urls')),
     url(r'^mobile/v1/', include('edx_solutions_api_integration.mobile_api.urls')),
     url(r'^imports/*', include('edx_solutions_api_integration.imports.urls')),
-    url(r'^courses_metadata/', include('course_metadata.urls')),
     # we have to explicitly define url for workgroup users detail view
     # to wrap it around non_atomic_requests decorator
     url(

--- a/edx_solutions_api_integration/users/views.py
+++ b/edx_solutions_api_integration/users/views.py
@@ -42,7 +42,6 @@ from openedx.core.djangoapps.user_api.models import UserPreference
 from openedx.core.djangoapps.user_api.accounts.api import delete_users
 from openedx.core.djangoapps.user_api.preferences.api import set_user_preference
 from edx_notifications.lib.consumer import mark_notification_read
-from course_metadata.models import CourseAggregatedMetaData, CourseSetting
 from completion_aggregator.models import Aggregator
 from student.models import CourseEnrollment, CourseEnrollmentException, PasswordHistory, UserProfile, LoginFailures
 from student.roles import (
@@ -1770,8 +1769,6 @@ class UsersCourseProgressList(SecureListAPIView):
                 aggregation_name='course'
             ).values('course_key', 'earned', 'possible', 'percent')
         }
-        course_meta_data = CourseAggregatedMetaData.objects.filter(id__in=course_keys)\
-            .values('id', 'total_assessments')
         course_overview = CourseOverview.objects.filter(id__in=course_keys)
         if str2bool(mobile_only):
             course_overview = course_overview.filter(mobile_available=True)
@@ -1790,7 +1787,6 @@ class UsersCourseProgressList(SecureListAPIView):
         serializer = CourseProgressSerializer(enrollments, many=True, context={
             'student_progress': student_progress,
             'course_overview': course_overview,
-            'course_metadata': course_meta_data,
             'user_grades': user_grades,
         })
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='2.5.13',
+    version='2.6.0',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
The data CourseAggregatedMetaData was storing is now provided by the completion aggregator, code using it and  signals keeping it in sync can be removed. 