### PR TITLE
MCKIN-10180: Add dummy poll response generator

### DIFF
--- a/edx_solutions_api_integration/management/commands/add_test_poll_responses.py
+++ b/edx_solutions_api_integration/management/commands/add_test_poll_responses.py
@@ -1,0 +1,177 @@
+"""
+Management command to migrate profile images from s3 bucket to open edx profile images storage
+./manage.py lms migrate_profile_images  --settings=aws --aws-access-key="x" --aws-access-secret="x" --bucket-name="b"
+"""
+
+import logging
+import datetime
+import urllib2 as urllib
+import io
+import random
+from itertools import product
+from collections import namedtuple
+
+from optparse import make_option
+from django.core.management.base import BaseCommand, CommandError
+
+from edx_solutions_api_integration.models import APIUser as User
+from course_blocks.api import get_course_blocks
+from opaque_keys.edx.keys import CourseKey
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore import ModuleStoreEnum
+
+from student.models import UserProfile
+from courseware.models import StudentModule
+
+from django.db import transaction
+
+
+# Variables
+
+log = logging.getLogger(__name__)
+
+# Classes
+
+
+class Command(BaseCommand):
+    """
+    Command to generate dummy problem responses xblock poll in a course
+    """
+    help = 'Generates dummy responses for users enrolled in a course'
+    option_list = BaseCommand.option_list + (
+        make_option(
+            "--course-id",
+            dest="course_id",
+            help="Course ID",
+        ),
+        make_option(
+            "--num-responses",
+            dest="num_responses",
+            default=10000,
+            type="int",
+            help="Limit generation of responses to this number. Defaults to "
+                 "generating 10k responses. Setting this to 0 will generate"
+                 "a dummy response for every user in every poll.",
+        ),
+    )
+
+    @staticmethod
+    def get_course_blocks(
+        store,
+        course_key,
+        categories,
+        revision=ModuleStoreEnum.RevisionOption.published_only
+    ):
+        """
+        Retrieve all XBlocks in the course for a particular category.
+
+        By default, only returns only XBlocks that are published.
+        """
+        return [
+            block for block in store.get_items(
+                course_key,
+                qualifiers={"category": categories},
+                revision=revision,
+            )
+        ]
+
+    @staticmethod
+    def get_enrolled_students(course_key):
+        """
+        Given a course_id, returns a QuerySet of all the active students
+        in the course.
+        """
+        students = UserProfile.objects.filter(
+            user__courseenrollment__course_id=course_key,
+            user__courseenrollment__is_active=True,
+        )
+        return students
+
+    @staticmethod
+    def generate_combinations(users, blocks, overwrite_answers=True):
+        combinations = product(users, blocks)
+
+        # Abandoning this for now
+        # if not overwrite_answers:
+        #     with transaction.atomic():
+        #         combinations = [
+        #             c for c in combinations if not StudentModule.objects.filter(
+        #                 student_id=c[0].user,
+        #                 module_state_key=c[1]
+        #             ).exists()
+        #         ]
+
+        return combinations
+
+    @staticmethod
+    def create_dummy_submissions(user, block):
+        """
+        Generates a random answers for a specified user and block
+
+        The currently supported blocks are poll and survey
+        """
+        def select_random_answer(choices):
+            return random.choices(choices)
+
+        if block.category == 'poll':
+            # Possible answers come in this format:
+            # ('G', {'img': None, 'img_alt': None, 'label': 'Green'})
+            # and we only need the 'G' bit for saving the answer
+            possible_answers = [a[0] for a in block.answers]
+            # Answer format for StudentModule model:
+            # {"submissions_count": 1, "choice": "R"}
+            answer = {
+                "submissions_count": 1,
+                "choice": random.choice(possible_answers),
+            }
+            print(answer)
+            # StudentModule.objects.create(
+            #     student_id=user,
+            #     state=answer,
+            # )
+        elif block.category == 'survey':
+            # Questions come in this format:
+            # ('enjoy', {'img': None, 'img_alt': None, 'label': 'Are you enjoying the course?'})
+            # and we only need the 'enjoy' part
+            questions = [q[0] for q in block.questions]
+            # This happens similarly with answers
+            possible_answers = [a[0] for a in block.answers]
+
+            # Answer format for StudentModule model:
+            # {"submissions_count": 1, "choices": {"enjoy": "Y", "learn": "Y", "recommend": "N"}}
+            answer = {
+                "submissions_count": 1,
+                "choices": {key: random.choice(possible_answers) for key in questions},
+            }
+
+            print(answer)
+
+    def handle(self, *args, **options):
+        """
+        Retrieves all XBlocks for a course and generates dummy reponses for
+        all users limited to --limit.
+
+        To use this command to generate answers for polls and suveys, you'll
+        need to create a course, add polls/surveys and users to it.
+        """
+        from django.db import connection
+        if not options.get('course_id'):
+            raise CommandError("add_test_poll_responses command requires the parameter --course-id")
+
+        store = modulestore()
+        course_key = CourseKey.from_string(options['course_id'])
+
+        # Get data from store and models
+        courses = store.get_course(course_key)
+        blocks = self.get_course_blocks(store, course_key, ['poll', 'survey'])
+        users = self.get_enrolled_students(course_key)
+
+        # Create product between users and polls
+        combinations = self.generate_combinations(users, blocks)
+        # import pdb; pdb.set_trace()
+
+        # Zip through items, limiting range with num_responses
+        for index, [user, block] in zip(range(options['num_responses']), combinations):
+            with transaction.atomic():
+                self.create_dummy_submissions(user, block)
+        import pdb; pdb.set_trace()

--- a/edx_solutions_api_integration/management/commands/add_test_poll_responses.py
+++ b/edx_solutions_api_integration/management/commands/add_test_poll_responses.py
@@ -162,7 +162,6 @@ class Command(BaseCommand):
         To use this command to generate answers for polls and suveys, you'll
         need to create a course, add polls/surveys and users to it.
         """
-        base = len(connection.queries)
         if not options.get('course_id'):
             raise CommandError("add_test_poll_responses command requires the parameter --course-id")
 
@@ -184,4 +183,3 @@ class Command(BaseCommand):
 
         if submissions:
             StudentModule.objects.bulk_create(submissions)
-        print(len(connection.queries)-base)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='2.6.1',
+    version='2.7.0',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
This PR adds a management command that creates dummy responses for polls and surveys for users enrolled in a course.

### **Testing instructions:**
1. On your solutions devstack, clone and install this branch.
2. Create a course with some polls and surveys (or import this one: [2019_T1.wJUdry.tar.gz](https://github.com/edx-solutions/api-integration/files/2983832/2019_T1.wJUdry.tar.gz)).
3. From `apros` [bulk import participants](http://apros.mcka.local/admin/participants) and add them to the course with the polls and surveys you just created. You can generate a CSV to bulk import users with:
```
with open('/tmp/participants.csv', 'w') as f:
    for i in range(int(1e4)):
        f.write(f"Bruce,Wayne,bruce{i}@wayne.com,1,TestX/TS101/2019_T1,participant\n")
```
4. Log in as a user and answer the polls.
5. Use the management command to bulk create dummy answers:
```
./manage.py lms add_test_poll_responses --settings=devstack --course-id=TestX/TS101/2019_T1
```
These are the available options: (tweak if needed)
```
  --course-id=COURSE_ID
                        Course ID
  --num-responses=NUM_RESPONSES
                        Limit generation of responses to this number. Defaults
                        to generating 10k responses. Setting this to 0 will
                        generate a dummy response for every user in every poll.
  --batch-size=BATCH_SIZE
                        Batch size to use when adding responses to the
                        database.
```
6. Check if the responses were correctly generated, from `./manage.py lms --settings=devstack shell`:
```
from courseware.models import StudentModule
StudentModule.objects.all().count()
```
7. Log into LMS and generate a problem response report for the course [here](http://lms.mcka.local/courses/TestX/TS101/2019_T1/instructor#view-data_download)
8. Check if the responses were correctly generated.

### **Performance testing:**

- **Query counting:** You can add these lines to the code to count the number of queries done when generating the answers:
```
from django.db import connection
# On the start of the management command
base = len(connection.queries)

# After the last line
logger.info("Number of queries: ", len(connection.queries)-base)
```
Keep in mind that these will vary depending on the batch size and number or generated responses.

- **CPU, Memory and time:** Run the management command like this: 
```
/usr/bin/time -v ./manage.py lms add_test_poll_responses --settings=devstack --course-id=TestX/TS101/2019_T1
```
You should get an output like this for generating ~10k users:
```
	Command being timed: "./manage.py lms add_test_poll_responses --settings=devstack --course-id=TestX/TS101/2019_T1"
	User time (seconds): 5.67
	System time (seconds): 0.95
	Percent of CPU this job got: 81%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:08.12
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 284524
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 0
	Minor (reclaiming a frame) page faults: 206907
	Voluntary context switches: 5204
	Involuntary context switches: 11921
	Swaps: 0
	File system inputs: 16
	File system outputs: 344
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0
```


### **Reviewer:**
- [ ] @xitij2000 