### PR TITLE
Fix profile image issue on editing username

### DIFF
--- a/edx_solutions_api_integration/users/views.py
+++ b/edx_solutions_api_integration/users/views.py
@@ -740,12 +740,15 @@ class UsersDetail(SecureAPIView):
             profile_image_names = get_profile_image_names(old_username)
             new_profile_image_names = get_profile_image_names(username)
             for old_image_size, old_image_name in profile_image_names.items():
-                for new_image_size, new_image_name in new_profile_image_names.items():
-                    if new_image_size == old_image_size:
-                        old_image_path = storage.path(old_image_name)
-                        new_image_path = storage.location + '/' + new_image_name
-                        if storage.exists(old_image_name):
-                            os.rename(old_image_path, new_image_path)
+                if storage.exists(old_image_name):
+                    for new_image_size, new_image_name in new_profile_image_names.items():
+                        if new_image_size == old_image_size:
+                            old_image_path = storage.path(old_image_name)
+                            new_image_path = storage.location + '/' + new_image_name
+                            try:
+                                os.rename(old_image_path, new_image_path)
+                            except OSError:
+                                raise
         if username:
             try:
                 validate_slug(username)

--- a/edx_solutions_api_integration/users/views.py
+++ b/edx_solutions_api_integration/users/views.py
@@ -763,9 +763,6 @@ class UsersDetail(SecureAPIView):
                                 old_image_path = storage.path(old_image_name)
                                 new_image_path = storage.location + '/' + new_image_name
                                 try:
-                                    print(old_image_path)
-                                    print(new_image_path)
-                                    print("nexttttttttttttttttttt")
                                     os.rename(old_image_path, new_image_path)
                                 except OSError:
                                     raise

--- a/edx_solutions_api_integration/users/views.py
+++ b/edx_solutions_api_integration/users/views.py
@@ -762,17 +762,12 @@ class UsersDetail(SecureAPIView):
                     if storage.exists(old_image_name):
                         try:
                             image_file = storage.open(old_image_name)
-                        except IOError:
-                            raise
-                        try:
                             storage.save(new_profile_image_names[old_image_size], ContentFile(image_file.read()))
-                        except Exception:
-                            raise
+                        except IOError:
+                            response_data['message'] = _('Could not update profile image')
+                            return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
                         else:
-                            try:
-                                storage.delete(old_image_name)
-                            except Exception:
-                                raise
+                            storage.delete(old_image_name)
 
         password = request.data.get('password')
         if password:

--- a/edx_solutions_api_integration/users/views.py
+++ b/edx_solutions_api_integration/users/views.py
@@ -752,14 +752,13 @@ class UsersDetail(SecureAPIView):
             existing_user.username = username
             response_data['username'] = existing_user.username
             existing_user.save()
-
             if old_username != username:
                 storage = get_profile_image_storage()
                 profile_image_names = get_profile_image_names(old_username)
                 new_profile_image_names = get_profile_image_names(username)
                 for old_image_size, old_image_name in profile_image_names.items():
                     if storage.exists(old_image_name):
-                        old_image_path = storage.path(old_image_name)
+                        old_image_path = os.path.join(storage.location, old_image_name)
                         new_image_path = os.path.join(storage.location, new_profile_image_names[old_image_size])
                         try:
                             os.rename(old_image_path, new_image_path)

--- a/edx_solutions_api_integration/users/views.py
+++ b/edx_solutions_api_integration/users/views.py
@@ -10,6 +10,7 @@ from functools import reduce
 from django.contrib.auth.models import Group
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.validators import validate_email, validate_slug, ValidationError
+from django.core.files.base import ContentFile
 from django.db import IntegrityError
 from django.db.models import Count, Q
 from django.conf import settings
@@ -759,25 +760,16 @@ class UsersDetail(SecureAPIView):
                 new_profile_image_names = get_profile_image_names(username)
                 for old_image_size, old_image_name in profile_image_names.items():
                     if storage.exists(old_image_name):
-                        old_image_path = os.path.join(storage.location, old_image_name)
-                        new_image_path = os.path.join(storage.location, new_profile_image_names[old_image_size])
                         try:
-                            os.rename(old_image_path, new_image_path)
+                            file = storage.open(old_image_name)
+                            storage.save(new_profile_image_names[old_image_size], ContentFile(file.read()))
                         except OSError:
                             raise
-
-            if old_username != username:
-                storage = get_profile_image_storage()
-                profile_image_names = get_profile_image_names(old_username)
-                new_profile_image_names = get_profile_image_names(username)
-                for old_image_size, old_image_name in profile_image_names.items():
-                    if storage.exists(old_image_name):
-                        old_image_path = storage.path(old_image_name)
-                        new_image_path = os.path.join(storage.location, new_profile_image_names[old_image_size])
-                        try:
-                            os.rename(old_image_path, new_image_path)
-                        except OSError:
-                            raise
+                        else:
+                            try:
+                                storage.delete(old_image_name)
+                            except OSError:
+                                raise
 
         password = request.data.get('password')
         if password:

--- a/edx_solutions_api_integration/users/views.py
+++ b/edx_solutions_api_integration/users/views.py
@@ -734,21 +734,6 @@ class UsersDetail(SecureAPIView):
         existing_user.save()
 
         username = request.data.get('username', None)
-        old_username = str(existing_user.username)
-        if username and old_username != username:
-            storage = get_profile_image_storage()
-            profile_image_names = get_profile_image_names(old_username)
-            new_profile_image_names = get_profile_image_names(username)
-            for old_image_size, old_image_name in profile_image_names.items():
-                if storage.exists(old_image_name):
-                    for new_image_size, new_image_name in new_profile_image_names.items():
-                        if new_image_size == old_image_size:
-                            old_image_path = storage.path(old_image_name)
-                            new_image_path = storage.location + '/' + new_image_name
-                            try:
-                                os.rename(old_image_path, new_image_path)
-                            except OSError:
-                                raise
         if username:
             try:
                 validate_slug(username)
@@ -756,6 +741,7 @@ class UsersDetail(SecureAPIView):
                 response_data['message'] = _('Username should only consist of A-Z and 0-9, with no spaces.')
                 return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
 
+            old_username = str(existing_user.username)
             existing_username = User.objects.filter(username=username).filter(~Q(id=user_id))
             if existing_username:
                 response_data['message'] = "User '%s' already exists" % (username)
@@ -765,6 +751,24 @@ class UsersDetail(SecureAPIView):
             existing_user.username = username
             response_data['username'] = existing_user.username
             existing_user.save()
+
+            if old_username != username:
+                storage = get_profile_image_storage()
+                profile_image_names = get_profile_image_names(old_username)
+                new_profile_image_names = get_profile_image_names(username)
+                for old_image_size, old_image_name in profile_image_names.items():
+                    if storage.exists(old_image_name):
+                        for new_image_size, new_image_name in new_profile_image_names.items():
+                            if new_image_size == old_image_size:
+                                old_image_path = storage.path(old_image_name)
+                                new_image_path = storage.location + '/' + new_image_name
+                                try:
+                                    print(old_image_path)
+                                    print(new_image_path)
+                                    print("nexttttttttttttttttttt")
+                                    os.rename(old_image_path, new_image_path)
+                                except OSError:
+                                    raise
 
         password = request.data.get('password')
         if password:

--- a/edx_solutions_api_integration/users/views.py
+++ b/edx_solutions_api_integration/users/views.py
@@ -761,14 +761,17 @@ class UsersDetail(SecureAPIView):
                 for old_image_size, old_image_name in profile_image_names.items():
                     if storage.exists(old_image_name):
                         try:
-                            file = storage.open(old_image_name)
-                            storage.save(new_profile_image_names[old_image_size], ContentFile(file.read()))
-                        except OSError:
+                            image_file = storage.open(old_image_name)
+                        except IOError:
+                            raise
+                        try:
+                            storage.save(new_profile_image_names[old_image_size], ContentFile(image_file.read()))
+                        except Exception:
                             raise
                         else:
                             try:
                                 storage.delete(old_image_name)
-                            except OSError:
+                            except Exception:
                                 raise
 
         password = request.data.get('password')

--- a/edx_solutions_api_integration/users/views.py
+++ b/edx_solutions_api_integration/users/views.py
@@ -42,6 +42,7 @@ from openedx.core.djangoapps.course_groups.cohorts import (
 from openedx.core.djangoapps.user_api.models import UserPreference
 from openedx.core.djangoapps.user_api.accounts.api import delete_users
 from openedx.core.djangoapps.user_api.preferences.api import set_user_preference
+from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_names, get_profile_image_storage
 from edx_notifications.lib.consumer import mark_notification_read
 from completion_aggregator.models import Aggregator
 from student.models import CourseEnrollment, CourseEnrollmentException, PasswordHistory, UserProfile, LoginFailures
@@ -93,7 +94,6 @@ from edx_solutions_api_integration.users.serializers import (
     UserRolesSerializer,
     CourseProgressSerializer,
 )
-from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_names, get_profile_image_storage
 
 log = logging.getLogger(__name__)
 AUDIT_LOG = logging.getLogger("audit")
@@ -758,14 +758,12 @@ class UsersDetail(SecureAPIView):
                 new_profile_image_names = get_profile_image_names(username)
                 for old_image_size, old_image_name in profile_image_names.items():
                     if storage.exists(old_image_name):
-                        for new_image_size, new_image_name in new_profile_image_names.items():
-                            if new_image_size == old_image_size:
-                                old_image_path = storage.path(old_image_name)
-                                new_image_path = storage.location + '/' + new_image_name
-                                try:
-                                    os.rename(old_image_path, new_image_path)
-                                except OSError:
-                                    raise
+                        old_image_path = storage.path(old_image_name)
+                        new_image_path = storage.location + '/' + new_profile_image_names[old_image_size]
+                        try:
+                            os.rename(old_image_path, new_image_path)
+                        except OSError:
+                            raise
 
         password = request.data.get('password')
         if password:

--- a/edx_solutions_api_integration/users/views.py
+++ b/edx_solutions_api_integration/users/views.py
@@ -760,7 +760,7 @@ class UsersDetail(SecureAPIView):
                 for old_image_size, old_image_name in profile_image_names.items():
                     if storage.exists(old_image_name):
                         old_image_path = storage.path(old_image_name)
-                        new_image_path = storage.location + '/' + new_profile_image_names[old_image_size]
+                        new_image_path = os.path.join(storage.location, new_profile_image_names[old_image_size])
                         try:
                             os.rename(old_image_path, new_image_path)
                         except OSError:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='2.6.0',
+    version='2.6.1',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='2.6.1',
+    version='2.8.0',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='2.7.4',
+    version='2.7.5',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
## [MCKIN-9977](https://edx-wiki.atlassian.net/browse/MCKIN-9977)

### Description
Profile image gets broken whenever we edit the username

The issue is fixed by copying the uploaded image files and saving them again for all four sizes according to the new username and then deleting the old images from storage.
The issue which we are facing on qa is fixed. Here is the link to the issue https://rpm.newrelic.com/accounts/631098/applications/4390895/traced_errors/fe236277-5c46-11e9-ada9-0242ac11000a_0_4365

### Testing
- [ ] Run coverage command and mention new % coverage
- [ ] This PR ensures security is maintained w.r.t input validations, output escaping/encoding and privileges against user roles

### Performance
- [ ] Can impact performance (Flag if these changes can affect app performance and add a corresponding JIRA ticket here to conduct performance testing)

### Dependencies
- [ ] This PR is dependent on any other PR or configuration or JIRA issue number; please mention here
- [ ] Includes migration
 
### Post-review
- [x] Rebase and squash commits before merge
