### PR TITLE
MCKIN-9499: update course overview and user courses api to return image urls

### DIFF
--- a/edx_solutions_api_integration/courses/tests.py
+++ b/edx_solutions_api_integration/courses/tests.py
@@ -37,6 +37,7 @@ from django.utils import timezone
 from django_comment_common.models import FORUM_ROLE_MODERATOR, Role
 from freezegun import freeze_time
 from instructor.access import allow_access
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 from requests.exceptions import ConnectionError
 from rest_framework import status
@@ -341,6 +342,7 @@ class CoursesApiTests(
             end=cls.course_end_date,
             language=cls.language,
         )
+        cls.course_overview = CourseOverview.get_from_id(cls.course.id)
         cls.test_data = '<html>{}</html>'.format(str(uuid.uuid4()))
 
         cls.chapter = ItemFactory.create(
@@ -1023,14 +1025,14 @@ class CoursesApiTests(
         self.assertGreater(len(response.data), 0)
         asset_id = self.test_course_id.split(":")[1]
         self.assertEqual(response.data['overview_html'], self.overview.data.format(asset_id, asset_id)[1:])
-        self.assertIn(self.course.course_image, response.data['course_image_url'])
+        self.assertEqual(self.course_overview.image_urls, response.data['course_image_urls'])
 
     def test_courses_overview_get_parsed(self):
         test_uri = self.base_courses_uri + '/' + self.test_course_id + '/overview?parse=true'
         response = self.do_get(test_uri)
         self.assertEqual(response.status_code, 200)
         self.assertGreater(len(response.data), 0)
-        self.assertIn(self.course.course_image, response.data['course_image_url'])
+        self.assertEqual(self.course_overview.image_urls, response.data['course_image_urls'])
         sections = response.data['sections']
         self.assertEqual(len(sections), 4)
         self.assertIsNotNone(self._find_item_by_class(sections, 'about'))

--- a/edx_solutions_api_integration/courses/views.py
+++ b/edx_solutions_api_integration/courses/views.py
@@ -996,10 +996,9 @@ class CoursesOverview(SecureAPIView):
             response_data['sections'] = _parse_overview_html(existing_content)
         else:
             response_data['overview_html'] = existing_content
-        image_url = ''
-        if hasattr(course_descriptor, 'course_image') and course_descriptor.course_image:
-            image_url = course_image_url(course_descriptor)
-        response_data['course_image_url'] = image_url
+
+        course_overview = CourseOverview.get_from_id(course_key)
+        response_data['course_image_urls'] = course_overview.image_urls
         response_data['course_video'] = get_course_about_section(request, course_descriptor, 'video')
         return Response(response_data, status=status.HTTP_200_OK)
 

--- a/edx_solutions_api_integration/users/views.py
+++ b/edx_solutions_api_integration/users/views.py
@@ -1091,7 +1091,7 @@ class UsersCoursesList(SecureAPIView):
                     "start": enrollment.course_overview.start,
                     "end": enrollment.course_overview.end,
                     "effort": enrollment.course_overview.effort,
-                    "course_image_url": enrollment.course_overview.course_image_url,
+                    "course_image_urls": enrollment.course_overview.image_urls,
                 }
                 response_data.append(course_data)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='2.7.8',
+    version='3.0.0',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
This PR updates course overview and user courses API to return course overview image set rather than returning full-sized raw image, which can sometimes be huge in size and take a lot of time to load causing bad user experience.

Testing Notes:
This change requires course overview image sets enabled, to enable it go to [course overview images config page](http://lms.mcka.local/admin/course_overviews/courseoverviewimageconfig/) in django admin and add new config.