### PR TITLE
MCKIN-11198: Total count of users is not appearing on cohort page

### DIFF
--- a/edx_solutions_api_integration/courses/views.py
+++ b/edx_solutions_api_integration/courses/views.py
@@ -434,7 +434,11 @@ def _get_courses_metrics_completions_leaders_list(course_key, **kwargs):
         if total_users > leader_boards_cache_cohort_size:
             cache_course_data('progress_leaderboard', course_id, {'leaders': data['leaders']})
     else:
-        cache_course_data('progress', course_id, {'course_avg': data['course_avg']})
+        cache_course_data('progress', course_id, {
+            'course_avg': data['course_avg'],
+            'total_users': data['total_users'],
+            'total_possible_completions': data['total_possible_completions'],
+        })
 
         # set user data in cache only if the user exists
         if user_id:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='3.1.4',
+    version='3.1.5',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
This PR caches total users count so that if course data is served from the cache it also contains total users count