### PR TITLE
MCKIN-11606 - regex fix for ooyala ids

### DIFF
--- a/edx_solutions_api_integration/tasks.py
+++ b/edx_solutions_api_integration/tasks.py
@@ -168,7 +168,7 @@ def cleanup_ooyala_tags(soup, bcove_policy):
     Remove any ooyala related scripts from given BeautifulSoup instance
     extract out associated bcove ids
     """
-    oo_reg = r"OO.Player.create\(['\"]\w+['\"],['\"]\w+['\"]"
+    oo_reg = r"OO.Player.create\(['\"]\w+['\"],['\"][\w+-]+['\"]"
     bcove_ids = []
     updated = False
 
@@ -183,6 +183,7 @@ def cleanup_ooyala_tags(soup, bcove_policy):
                 parts = match.group().split(',')
                 if len(parts) > 1:
                     oo_id = parts[1].strip("'")
+                    print oo_id
 
                     if not is_bcove_id(oo_id):
                         bcove_id = get_brightcove_video_id(oo_id, bcove_policy)

--- a/edx_solutions_api_integration/tasks.py
+++ b/edx_solutions_api_integration/tasks.py
@@ -183,7 +183,6 @@ def cleanup_ooyala_tags(soup, bcove_policy):
                 parts = match.group().split(',')
                 if len(parts) > 1:
                     oo_id = parts[1].strip("'")
-                    print oo_id
 
                     if not is_bcove_id(oo_id):
                         bcove_id = get_brightcove_video_id(oo_id, bcove_policy)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='api-integration',
-    version='3.1.10',
+    version='3.1.11',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
Ooyala IDs can also contain hyphens `-`. Modified regex to support it.