### PR TITLE
moving setup configs for solutions_api from lms/strartup.py to apps.py

### DIFF
--- a/edx_solutions_api_integration/apps.py
+++ b/edx_solutions_api_integration/apps.py
@@ -2,6 +2,7 @@
 app configuration
 """
 from django.apps import AppConfig
+from django.conf import settings
 
 
 class SolutionsAppApiIntegrationConfig(AppConfig):
@@ -13,3 +14,15 @@ class SolutionsAppApiIntegrationConfig(AppConfig):
 
         # import signal handlers
         import edx_solutions_api_integration.receivers  # pylint: disable=unused-import
+
+        if settings.FEATURES.get('EDX_SOLUTIONS_API', False) and \
+                settings.FEATURES.get('DISABLE_SOLUTIONS_APPS_SIGNALS', False):
+            disable_solutions_apps_signals()
+
+
+def disable_solutions_apps_signals():
+    """
+    Disables signals receivers in solutions apps
+    """
+    from edx_solutions_api_integration.test_utils import SignalDisconnectTestMixin
+    SignalDisconnectTestMixin.disconnect_signals()


### PR DESCRIPTION
In ironwood platform is moving all startup code to more standard locations using Django best practices. I have moved solutions_api configs to api-integrations and removed from lms/startup.py