### PR TITLE
MCKIN-28615 - fix bytes conversion

### DIFF
--- a/edx_solutions_api_integration/sessions/views.py
+++ b/edx_solutions_api_integration/sessions/views.py
@@ -270,8 +270,8 @@ class AssetsToken(APIView):
         except KeyError:
             user = AnonymousUser()
         if user.is_authenticated:
-            response_data['assets_token'] = Fernet(bytes(settings.ASSETS_TOKEN_ENCRYPTION_KEY))\
-                .encrypt(bytes(session.session_key))
+            response_data['assets_token'] = Fernet(bytes(settings.ASSETS_TOKEN_ENCRYPTION_KEY, 'utf-8'))\
+                .encrypt(bytes(session.session_key, 'utf-8'))
             return Response(response_data, status=status.HTTP_200_OK)
         else:
             return Response(response_data, status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
`bytes` needs encoding argument:

```
edx.devstack-juniper.lms |   File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/rest_framework/views.py", line 492, in dispatch
edx.devstack-juniper.lms |     response = handler(request, *args, **kwargs)
edx.devstack-juniper.lms |   File "/edx/src/api-integration/edx_solutions_api_integration/sessions/views.py", line 273, in get
edx.devstack-juniper.lms |     response_data['assets_token'] = Fernet(bytes(settings.ASSETS_TOKEN_ENCRYPTION_KEY))\
edx.devstack-juniper.lms | TypeError: string argument without an encoding
edx.devstack-juniper.lms | [21/Dec/2020 11:25:28] "GET /api/server/sessions/ggylrh1l80r7x9yb1hf6k23lu588co2h/assets_token HTTP/1.0" 500 126108
```