### PR TITLE
MCKIN-29700 existing user enrollments issue

### DIFF
--- a/edx_solutions_api_integration/imports/views.py
+++ b/edx_solutions_api_integration/imports/views.py
@@ -209,9 +209,7 @@ class ImportParticipantsViewSet(SecureViewSet):
         try:
             add_user_to_cohort(cohort, user.username)
         except ValueError:
-            # This situation can occur if user is already present in the cohort probably because they were un-enrolled
-            # and re-enrolled or if his enrollment was removed
-            # manually from Django Admin. We can ignore this error.
+            # This situation can occur if user is already present in the cohort for the course.
             pass
 
         # Assign role and permission in course.

--- a/edx_solutions_api_integration/imports/views.py
+++ b/edx_solutions_api_integration/imports/views.py
@@ -19,7 +19,7 @@ from edx_solutions_organizations.models import Organization
 from rest_framework.decorators import list_route
 
 from lms.djangoapps.notification_prefs.views import enable_notifications
-from openedx.core.djangoapps.course_groups.cohorts import add_cohort, get_cohort_by_name
+from openedx.core.djangoapps.course_groups.cohorts import add_cohort, get_cohort_by_name, add_user_to_cohort
 from openedx.core.djangoapps.course_groups.models import CohortMembership, CourseCohort, CourseUserGroup
 from student.models import CourseEnrollment, UserProfile
 
@@ -207,9 +207,10 @@ class ImportParticipantsViewSet(SecureViewSet):
         cohort = get_cohort_by_name(course_key, CourseUserGroup.default_cohort_name)
 
         try:
-            CohortMembership.objects.create(course_user_group=cohort, user=user)
-        except IntegrityError:
-            # This situation can occur if user is already present in the course or if his enrollment was removed
+            add_user_to_cohort(cohort, user.username)
+        except ValueError:
+            # This situation can occur if user is already present in the cohort probably because they were un-enrolled
+            # and re-enrolled or if his enrollment was removed
             # manually from Django Admin. We can ignore this error.
             pass
 


### PR DESCRIPTION
CourseEnrollment does not update enrollment status when we face an integrity error on `CohortMembership.objects.create` during enrolling user to the same course multiple times. Used platform build-in function to avoid integrity.

Steps to reproduce:

1. Try to enroll user through the feature `Enroll existing participants`
2. unenroll this user from the course
3. Repeat it, the course will not be shown in the user's active courses. 