### PR TITLE
MCKIN-30711 - Fixing errors in management command

### DIFF
--- a/edx_solutions_api_integration/management/commands/add_test_poll_responses.py
+++ b/edx_solutions_api_integration/management/commands/add_test_poll_responses.py
@@ -39,7 +39,7 @@ class Command(BaseCommand):
             "--num-responses",
             dest="num_responses",
             default=10000,
-            type="int",
+            type=int,
             help="Limit generation of responses to this number. Defaults to "
                  "generating 10k responses. Setting this to 0 will generate"
                  "a dummy response for every user in every poll.",
@@ -48,7 +48,7 @@ class Command(BaseCommand):
             "--batch-size",
             dest="batch_size",
             default=500,
-            type="int",
+            type=int,
             help="Batch size to use when adding responses to the database.",
         ),
     state_summary = {}
@@ -104,7 +104,7 @@ class Command(BaseCommand):
         count = 0
         # Returns generator of combinations that aren't already stored
         for student, block in combinations:
-            if count >= limit:
+            if limit and count >= limit:
                 break
             if (student, str(block.location)) not in skip_combinations:
                 count += 1

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='api-integration',
-    version='5.0.1',
+    version='5.0.2',
     description='RESTful api integration for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
Fixing errors in existing management command to add test polls data. Fixed types of arguments. Also added check that if argument `num-responses` is 0 than dummy response will be generated for each user as mentioned in the comments.